### PR TITLE
aliases: handle uppercase product names

### DIFF
--- a/www/www-deploy.yml
+++ b/www/www-deploy.yml
@@ -37,6 +37,12 @@
 
     nginx_proxy_redirect_map_locations:
     # TODO: change to 301 when we're happy
+    - location: "~ ^/(BIO-FORMATS)($|/)"
+      code: 302
+    - location: "~ ^/(OME-FILES)($|/)"
+      code: 302
+    - location: "~ ^/(OMERO)($|/)"
+      code: 302
     - location: "~ ^/(site)($|/)"
       code: 302
     - location: "~ ^/(omero-blog)($|/)"
@@ -201,6 +207,20 @@
       dest: https://docs.openmicroscopy.org
     - match: "~/site/support/ome-artwork(/.*)?$"
       dest: /artwork
+
+    # uppercase alias
+    - match: "~/BIO-FORMATS$"
+      dest: /bio-formats
+    - match: "~/BIO-FORMATS/(?<link>.*)$"
+      dest: /bio-formats/$link
+    - match: "~/OME-FILES$"
+      dest: /ome-files
+    - match: "~/OME-FILES/(?<link>.*)$"
+      dest: /ome-files/$link
+    - match: "~/OMERO$"
+      dest: /omero
+    - match: "~/OMERO/(?<link>.*)$"
+      dest: /omero/$link
 
     # info
     - match: "~/info/vulnerabilities/?$"


### PR DESCRIPTION
Since our logos are all uppercase, placing "openmicroscopy.org" in
front of them might encourage someone to go, for example,
openmicroscopy.org/OMERO which currently is 404.

This has been run on ome-www-dev with:

```
ansible-playbook -i ../ansible/inventory/staging-hosts  playbooks/www/www-deploy.yml --ask-become
```

Test with:
 * https://ome-www-dev.openmicroscopy.org/OMERO/
 * https://ome-www-dev.openmicroscopy.org/BIO-FORMATS/downloads
 * etc.
