### PR TITLE
Install git on outreach

### DIFF
--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -49,6 +49,8 @@
         databases: [omero]
       postgresql_version: "9.6"
 
+    - role: openmicroscopy.versioncontrol-utils
+
     - role: openmicroscopy.nfs-mount
 
     - role: openmicroscopy.omero-server

--- a/requirements.yml
+++ b/requirements.yml
@@ -104,6 +104,9 @@
 - src: openmicroscopy.upgrade-distpackages
   version: 1.1.0
 
+- src: openmicroscopy.versioncontrol-utils
+  version: 1.0.1
+
 - name: idr.idr-jupyter
   src: idr.ansible-role-idr-jupyter
   version: 3.0.0


### PR DESCRIPTION
Discussed with @sbesson : Git installation on outreach is of advantage to be able to manage the versions of the training scripts there (maintenance mainly) .

Second goal here is to be able to clone idr repos and thus use the bulk.yml and tsv files from there easily.


@jburel @manics @joshmoore 