### PR TITLE
Propose new forums location: data-management

### DIFF
--- a/molecule/www/tests/test_redirects.py
+++ b/molecule/www/tests/test_redirects.py
@@ -6,7 +6,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 external_uris = [
-    ('/forums', 'https://forum.image.sc/tags/ome'),
+    ('/forums', 'https://forum.image.sc/c/data-management'),
     ('/omero-blog', 'http://blog.openmicroscopy.org'),
     ('/site/about/development-teams/glencoe-software',
      'https://www.glencoesoftware.com/team.html'),

--- a/www/www-deploy.yml
+++ b/www/www-deploy.yml
@@ -115,7 +115,7 @@
 
     # community
     - match: "~/forums/?$"
-      dest: https://forum.image.sc/tags/ome
+      dest: https://forum.image.sc/c/data-management
     - match: "~/site/community/?$"
       dest: /support
     - match: "~/site/community/mailing-lists/?$"


### PR DESCRIPTION
For discussion: Now that /support explicitly lists tags (https://github.com/ome/www.openmicroscopy.org/pull/298), perhaps the overall link can go to the new category?