### PR TITLE
mencoder cleanup

### DIFF
--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -9,12 +9,6 @@
         name:  http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
         state: present
 
-    - name: Install Make Movie script Prerequisite | MEncoder - Package
-      become: yes
-      yum:
-        name: mencoder
-        state: present
-
     - name: OMERO.figure server-side prerequisites, script prerequisites + web server for decoupled OMERO.web
       become: yes
       yum:


### PR DESCRIPTION
remove duplicate
Installation already covered by 
```
    - name: OMERO.figure server-side prerequisites, script prerequisites + web server for decoupled OMERO.web
      become: yes
      yum:
        name: "{{ item }}"
        state: present
      with_items:
        - python-reportlab # For OMERO.figure
        - python-markdown # For OMERO.figure
        - mencoder # For the 'make movie' script
        - scipy
        - python-matplotlib # For "simple frap with figure" script
```