### PR TITLE
Add molecule tests for release playbooks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,6 @@ env:
   - SCENARIO=ome-demoserver
   - SCENARIO=ome-dundeeomero
   - SCENARIO=omero-training-server
+  - SCENARIO=release
   - SCENARIO=web-proxy
   - SCENARIO=www

--- a/molecule/release/Dockerfile.j2
+++ b/molecule/release/Dockerfile.j2
@@ -1,0 +1,1 @@
+../resources/Dockerfile.j2

--- a/molecule/release/molecule.yml
+++ b/molecule/release/molecule.yml
@@ -1,0 +1,29 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+  # TODO: enable
+  enabled: False
+platforms:
+  - name: idr0-slot3.openmicroscopy.org
+    image: centos:7
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ../../release/release-acceptance.yml
+  inventory:
+    host_vars:
+      idr0-slot3.openmicroscopy.org:
+        product: component
+        version: 3.2.10
+  lint:
+    name: ansible-lint
+scenario:
+  name: release
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/molecule/release/prepare.yml
+++ b/molecule/release/prepare.yml
@@ -1,0 +1,19 @@
+---
+- hosts: idr0-slot3.openmicroscopy.org
+  vars:
+    www_folders:
+      - /uod/idr/www/docs.openmicroscopy.org
+      - /uod/idr/www/downloads.openmicroscopy.org
+  tasks:
+  - file:
+     path: "{{ item }}/component/3.2.10"
+     state: directory
+    with_items: "{{ www_folders }}"
+  - file:
+     path: "{{ item }}//component/3.2.10/.htaccess"
+     state: touch
+    with_items: "{{ www_folders }}"
+  - file:
+     path: "{{ item }}//component/3.2.10/test"
+     state: touch
+    with_items: "{{ www_folders }}"

--- a/molecule/release/tests/test_default.py
+++ b/molecule/release/tests/test_default.py
@@ -1,0 +1,22 @@
+import os
+import pytest
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+DOWNLOADS_URL = "/uod/idr/www/downloads.openmicroscopy.org"
+DOCS_URL = "/uod/idr/www/docs.openmicroscopy.org"
+
+
+@pytest.mark.parametrize('base_folder', [DOWNLOADS_URL, DOCS_URL])
+def test_htaccess(host, base_folder):
+    assert not host.file('%s/component/3.2.10/.htaccess' % base_folder).exists
+
+
+@pytest.mark.parametrize('base_folder', [DOWNLOADS_URL, DOCS_URL])
+def test_permissions(host, base_folder):
+    f = host.file('%s/component/3.2.10' % base_folder)
+    assert f.exists
+    assert f.user == 'root'
+    assert oct(f.mode) == '01555'

--- a/release/release-acceptance.yml
+++ b/release/release-acceptance.yml
@@ -2,18 +2,22 @@
 - hosts: idr0-slot3.openmicroscopy.org
   become: true
   tasks:
-    - stat:
-        path: "/uod/idr/www/downloads.openmicroscopy.org/{{ product }}/{{ version }}/"
+    - name: Check that the release component exists
+      stat:
+        path: "/uod/idr/www/downloads.openmicroscopy.org/\
+          {{ product }}/{{ version }}/"
       register: s
       when: product is defined and version is defined
 
-    - file:
+    - name: Remove .htaccess file
+      file:
         path: "{{ item }}/{{ product }}/{{ version }}/.htaccess"
         state: absent
       when: s.stat is defined and s.stat.exists
       with_items: "{{ www_folders }}"
 
-    - file:
+    - name: Make release folders read-only and owned by roo
+      file:
         path: "{{ item }}/{{ product }}/{{ version }}"
         state: directory
         owner: root


### PR DESCRIPTION
In preparation of upcoming proposals to the release playbook, this creates a molecule scenario testing the outcome of the `release-acceptance.yml` playbook (`.htacces` removal + ownership/permissions)