### PR TITLE
Versioned URL variants

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,6 @@ env:
   - SCENARIO=ome-demoserver
   - SCENARIO=ome-dundeeomero
   - SCENARIO=omero-training-server
+  - SCENARIO=release
   - SCENARIO=web-proxy
   - SCENARIO=www

--- a/molecule/release/Dockerfile.j2
+++ b/molecule/release/Dockerfile.j2
@@ -1,0 +1,1 @@
+../resources/Dockerfile.j2

--- a/molecule/release/molecule.yml
+++ b/molecule/release/molecule.yml
@@ -8,16 +8,26 @@ lint:
   # TODO: enable
   enabled: False
 platforms:
-  - name: idr0-slot3.openmicroscopy.org
+  - name: release
     image: centos:7
+    groups:
+      - idr0-slot3.openmicroscopy.org
+  - name: prerelease
+    image: centos:7
+    groups:
+      - idr0-slot3.openmicroscopy.org
 provisioner:
   name: ansible
   playbooks:
     converge: ../../release/release-acceptance.yml
   inventory:
-    host_vars:
+    group_vars:
       idr0-slot3.openmicroscopy.org:
         product: component
+    host_vars:
+      prerelease:
+        version: '3.2.0-rc1'
+      release:
         version: 3.2.0
   lint:
     name: ansible-lint

--- a/molecule/release/molecule.yml
+++ b/molecule/release/molecule.yml
@@ -1,0 +1,29 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+  # TODO: enable
+  enabled: False
+platforms:
+  - name: idr0-slot3.openmicroscopy.org
+    image: centos:7
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ../../release/release-acceptance.yml
+  inventory:
+    host_vars:
+      idr0-slot3.openmicroscopy.org:
+        product: component
+        version: 3.2.10
+  lint:
+    name: ansible-lint
+scenario:
+  name: release
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/molecule/release/molecule.yml
+++ b/molecule/release/molecule.yml
@@ -18,7 +18,7 @@ provisioner:
     host_vars:
       idr0-slot3.openmicroscopy.org:
         product: component
-        version: 3.2.10
+        version: 3.2.0
   lint:
     name: ansible-lint
 scenario:

--- a/molecule/release/prepare.yml
+++ b/molecule/release/prepare.yml
@@ -5,15 +5,46 @@
       - /uod/idr/www/docs.openmicroscopy.org
       - /uod/idr/www/downloads.openmicroscopy.org
   tasks:
-  - file:
-     path: "{{ item }}/component/3.2.10"
+  - name: Create existing released components
+    file:
+     path: "{{ item }}/component/3.1.8"
      state: directory
+     owner: root
+     group: root
+     mode: 01555
     with_items: "{{ www_folders }}"
-  - file:
-     path: "{{ item }}//component/3.2.10/.htaccess"
+  - name: Create existing minor version symlinks
+    file:
+     src: "{{ item }}/component/3.1.8"
+     dest: "{{ item }}/component/3.1"
+     state: link
+    with_items: "{{ www_folders }}"
+  - name: Create existing major version symlinks
+    file:
+     src: "{{ item }}/component/3.1.8"
+     dest: "{{ item }}/component/3"
+     state: link
+    with_items: "{{ www_folders }}"
+  - name: Create existing latest version symlinks
+    file:
+     src: "{{ item }}/component/3.1.8"
+     dest: "{{ item }}/component/latest"
+     state: link
+    with_items: "{{ www_folders }}"
+  - name: Create new release components
+    file:
+     path: "{{ item }}/component/3.2.0"
+     state: directory
+     mode: 01777
+    with_items: "{{ www_folders }}"
+  - name: Create .htaccess file
+    file:
+     path: "{{ item }}/component/3.2.0/.htaccess"
      state: touch
     with_items: "{{ www_folders }}"
-  - file:
-     path: "{{ item }}//component/3.2.10/test"
+  - name: Create mock content
+    file:
+     path: "{{ item }}/component/3.2.0/test"
      state: touch
+     mode: 01777
     with_items: "{{ www_folders }}"

--- a/molecule/release/prepare.yml
+++ b/molecule/release/prepare.yml
@@ -1,0 +1,19 @@
+---
+- hosts: idr0-slot3.openmicroscopy.org
+  vars:
+    www_folders:
+      - /uod/idr/www/docs.openmicroscopy.org
+      - /uod/idr/www/downloads.openmicroscopy.org
+  tasks:
+  - file:
+     path: "{{ item }}/component/3.2.10"
+     state: directory
+    with_items: "{{ www_folders }}"
+  - file:
+     path: "{{ item }}//component/3.2.10/.htaccess"
+     state: touch
+    with_items: "{{ www_folders }}"
+  - file:
+     path: "{{ item }}//component/3.2.10/test"
+     state: touch
+    with_items: "{{ www_folders }}"

--- a/molecule/release/prepare.yml
+++ b/molecule/release/prepare.yml
@@ -1,9 +1,12 @@
 ---
-- hosts: idr0-slot3.openmicroscopy.org
+- hosts: all
   vars:
     www_folders:
       - /uod/idr/www/docs.openmicroscopy.org
       - /uod/idr/www/downloads.openmicroscopy.org
+    releases:
+      - 3.2.0
+      - 3.2.0-rc1
   tasks:
   - name: Create existing released components
     file:
@@ -33,18 +36,24 @@
     with_items: "{{ www_folders }}"
   - name: Create new release components
     file:
-     path: "{{ item }}/component/3.2.0"
+     path: "{{ item[0] }}/component/{{ item[1] }}"
      state: directory
      mode: 01777
-    with_items: "{{ www_folders }}"
+    with_nested:
+      - "{{ www_folders }}"
+      - "{{ releases }}"
   - name: Create .htaccess file
     file:
-     path: "{{ item }}/component/3.2.0/.htaccess"
+     path: "{{ item[0] }}/component/{{ item[1] }}/.htaccess"
      state: touch
-    with_items: "{{ www_folders }}"
+    with_nested:
+      - "{{ www_folders }}"
+      - "{{ releases }}"
   - name: Create mock content
     file:
-     path: "{{ item }}/component/3.2.0/test"
+     path: "{{ item[0] }}/component/{{ item[1] }}/test"
      state: touch
      mode: 01777
-    with_items: "{{ www_folders }}"
+    with_nested:
+      - "{{ www_folders }}"
+      - "{{ releases }}"

--- a/molecule/release/tests/test_default.py
+++ b/molecule/release/tests/test_default.py
@@ -10,13 +10,12 @@ DOCS_URL = "/uod/idr/www/docs.openmicroscopy.org"
 
 
 @pytest.mark.parametrize('base_folder', [DOWNLOADS_URL, DOCS_URL])
-def test_htaccess(host, base_folder):
-    assert not host.file('%s/component/3.2.0/.htaccess' % base_folder).exists
-
-
-@pytest.mark.parametrize('base_folder', [DOWNLOADS_URL, DOCS_URL])
 def test_permissions(host, base_folder):
-    f = host.file('%s/component/3.2.0' % base_folder)
+    v = host.ansible.get_variables()
+    assert not host.file('%s/component/%s/.htaccess' % (
+        base_folder, v['version'])).exists
+
+    f = host.file('%s/component/%s' % (base_folder, v['version']))
     assert f.exists
     assert f.user == 'root'
     assert oct(f.mode) == '01555'
@@ -24,12 +23,13 @@ def test_permissions(host, base_folder):
 
 @pytest.mark.parametrize('base_folder', [DOWNLOADS_URL, DOCS_URL])
 def test_symlinks(host, base_folder):
+    v = host.ansible.get_variables()
     f = host.file('%s/component/3.2' % base_folder)
     assert f.is_symlink
-    assert f.linked_to == '%s/component/3.2.0' % base_folder
+    assert f.linked_to == '%s/component/%s' % (base_folder, v['version'])
     f = host.file('%s/component/3' % base_folder)
     assert f.is_symlink
-    assert f.linked_to == '%s/component/3.2.0' % base_folder
+    assert f.linked_to == '%s/component/%s' % (base_folder, v['version'])
     f = host.file('%s/component/latest' % base_folder)
     assert f.is_symlink
-    assert f.linked_to == '%s/component/3.2.0' % base_folder
+    assert f.linked_to == '%s/component/%s' % (base_folder, v['version'])

--- a/molecule/release/tests/test_default.py
+++ b/molecule/release/tests/test_default.py
@@ -1,0 +1,22 @@
+import os
+import pytest
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+DOWNLOADS_URL = "/uod/idr/www/downloads.openmicroscopy.org"
+DOCS_URL = "/uod/idr/www/docs.openmicroscopy.org"
+
+
+@pytest.mark.parametrize('base_folder', [DOWNLOADS_URL, DOCS_URL])
+def test_htaccess(host, base_folder):
+    assert not host.file('%s/component/3.2.10/.htaccess' % base_folder).exists
+
+
+@pytest.mark.parametrize('base_folder', [DOWNLOADS_URL, DOCS_URL])
+def test_permissions(host, base_folder):
+    f = host.file('%s/component/3.2.10' % base_folder)
+    assert f.exists
+    assert f.user == 'root'
+    assert oct(f.mode) == '01555'

--- a/molecule/release/tests/test_default.py
+++ b/molecule/release/tests/test_default.py
@@ -20,3 +20,16 @@ def test_permissions(host, base_folder):
     assert f.exists
     assert f.user == 'root'
     assert oct(f.mode) == '01555'
+
+
+@pytest.mark.parametrize('base_folder', [DOWNLOADS_URL, DOCS_URL])
+def test_symlinks(host, base_folder):
+    f = host.file('%s/component/3.2' % base_folder)
+    assert f.is_symlink
+    assert f.linked_to == '%s/component/3.2.10' % base_folder
+    f = host.file('%s/component/3' % base_folder)
+    assert f.is_symlink
+    assert f.linked_to == '%s/component/3.2.10' % base_folder
+    f = host.file('%s/component/latest' % base_folder)
+    assert f.is_symlink
+    assert f.linked_to == '%s/component/3.2.10' % base_folder

--- a/molecule/release/tests/test_default.py
+++ b/molecule/release/tests/test_default.py
@@ -24,12 +24,22 @@ def test_permissions(host, base_folder):
 @pytest.mark.parametrize('base_folder', [DOWNLOADS_URL, DOCS_URL])
 def test_symlinks(host, base_folder):
     v = host.ansible.get_variables()
+    hostname = host.backend.get_hostname()
     f = host.file('%s/component/3.2' % base_folder)
-    assert f.is_symlink
-    assert f.linked_to == '%s/component/%s' % (base_folder, v['version'])
+    if hostname == 'release':
+        assert f.is_symlink
+        assert f.linked_to == '%s/component/%s' % (base_folder, v['version'])
+    elif hostname == 'prelease':
+        assert not f.exists
     f = host.file('%s/component/3' % base_folder)
     assert f.is_symlink
-    assert f.linked_to == '%s/component/%s' % (base_folder, v['version'])
+    if hostname == 'release':
+        assert f.linked_to == '%s/component/%s' % (base_folder, v['version'])
+    elif hostname == 'prelease':
+        assert f.linked_to == '%s/component/3.1.8' % base_folder
     f = host.file('%s/component/latest' % base_folder)
     assert f.is_symlink
-    assert f.linked_to == '%s/component/%s' % (base_folder, v['version'])
+    if hostname == 'release':
+        assert f.linked_to == '%s/component/%s' % (base_folder, v['version'])
+    elif hostname == 'prelease':
+        assert f.linked_to == '%s/component/3.1.8' % base_folder

--- a/molecule/release/tests/test_default.py
+++ b/molecule/release/tests/test_default.py
@@ -11,12 +11,12 @@ DOCS_URL = "/uod/idr/www/docs.openmicroscopy.org"
 
 @pytest.mark.parametrize('base_folder', [DOWNLOADS_URL, DOCS_URL])
 def test_htaccess(host, base_folder):
-    assert not host.file('%s/component/3.2.10/.htaccess' % base_folder).exists
+    assert not host.file('%s/component/3.2.0/.htaccess' % base_folder).exists
 
 
 @pytest.mark.parametrize('base_folder', [DOWNLOADS_URL, DOCS_URL])
 def test_permissions(host, base_folder):
-    f = host.file('%s/component/3.2.10' % base_folder)
+    f = host.file('%s/component/3.2.0' % base_folder)
     assert f.exists
     assert f.user == 'root'
     assert oct(f.mode) == '01555'
@@ -26,10 +26,10 @@ def test_permissions(host, base_folder):
 def test_symlinks(host, base_folder):
     f = host.file('%s/component/3.2' % base_folder)
     assert f.is_symlink
-    assert f.linked_to == '%s/component/3.2.10' % base_folder
+    assert f.linked_to == '%s/component/3.2.0' % base_folder
     f = host.file('%s/component/3' % base_folder)
     assert f.is_symlink
-    assert f.linked_to == '%s/component/3.2.10' % base_folder
+    assert f.linked_to == '%s/component/3.2.0' % base_folder
     f = host.file('%s/component/latest' % base_folder)
     assert f.is_symlink
-    assert f.linked_to == '%s/component/3.2.10' % base_folder
+    assert f.linked_to == '%s/component/3.2.0' % base_folder

--- a/release/release-acceptance.yml
+++ b/release/release-acceptance.yml
@@ -19,6 +19,11 @@
       with_items: "{{ s.results }}"
       when: item.stat is not defined or not item.stat.exists
 
+    - name: Check pre-release
+      set_fact:
+        prelease: True
+      when: "'-' in version"
+
     - name: Define minor and major versions
       set_fact:
         minorversion: "{{ version.split('.')[:2] | join('.') }}"
@@ -46,6 +51,7 @@
         dest: "{{ item }}/{{ product }}/{{ minorversion }}"
         state: link
       with_items: "{{ www_folders }}"
+      when: prelease is not defined
 
     - name: Create major version symlink
       file:
@@ -53,6 +59,7 @@
         dest: "{{ item }}/{{ product }}/{{ majorversion }}"
         state: link
       with_items: "{{ www_folders }}"
+      when: prelease is not defined
 
     - name: Create latest version symlink
       file:
@@ -60,3 +67,4 @@
         dest: "{{ item }}/{{ product }}/latest"
         state: link
       with_items: "{{ www_folders }}"
+      when: prelease is not defined

--- a/release/release-acceptance.yml
+++ b/release/release-acceptance.yml
@@ -21,8 +21,7 @@
 
     - name: Check pre-release
       set_fact:
-        prelease: True
-      when: "'-' in version"
+        prerelease: "{{ '-' in version }}"
 
     - name: Define minor and major versions
       set_fact:
@@ -51,7 +50,7 @@
         dest: "{{ item }}/{{ product }}/{{ minorversion }}"
         state: link
       with_items: "{{ www_folders }}"
-      when: prelease is not defined
+      when: not prerelease
 
     - name: Create major version symlink
       file:
@@ -59,7 +58,7 @@
         dest: "{{ item }}/{{ product }}/{{ majorversion }}"
         state: link
       with_items: "{{ www_folders }}"
-      when: prelease is not defined
+      when: not prerelease
 
     - name: Create latest version symlink
       file:
@@ -67,4 +66,4 @@
         dest: "{{ item }}/{{ product }}/latest"
         state: link
       with_items: "{{ www_folders }}"
-      when: prelease is not defined
+      when: not prerelease

--- a/release/release-acceptance.yml
+++ b/release/release-acceptance.yml
@@ -4,7 +4,7 @@
   tasks:
     - name: Check mandatory variables are defined
       fail:
-        msg: Please pass 'product' and 'version variables'
+        msg: Please pass 'product' and 'version' variables
       when: product is not defined and version is not defined
 
     - name: Check the release component exist

--- a/release/release-acceptance.yml
+++ b/release/release-acceptance.yml
@@ -2,18 +2,22 @@
 - hosts: idr0-slot3.openmicroscopy.org
   become: true
   tasks:
-    - stat:
-        path: "/uod/idr/www/downloads.openmicroscopy.org/{{ product }}/{{ version }}/"
+    - name: Check that the release component exists
+      stat:
+        path: "/uod/idr/www/downloads.openmicroscopy.org/\
+          {{ product }}/{{ version }}/"
       register: s
       when: product is defined and version is defined
 
-    - file:
+    - name: Remove .htaccess file
+      file:
         path: "{{ item }}/{{ product }}/{{ version }}/.htaccess"
         state: absent
       when: s.stat is defined and s.stat.exists
       with_items: "{{ www_folders }}"
 
-    - file:
+    - name: Make release folders read-only and owned by roo
+      file:
         path: "{{ item }}/{{ product }}/{{ version }}"
         state: directory
         owner: root

--- a/release/release-acceptance.yml
+++ b/release/release-acceptance.yml
@@ -9,6 +9,11 @@
       register: s
       when: product is defined and version is defined
 
+    - name: Define minor and major versions
+      set_fact:
+        minorversion: "{{ version.split('.')[:2] | join('.') }}"
+        majorversion: "{{ version.split('.')[:1] | join('.') }}"
+
     - name: Remove .htaccess file
       file:
         path: "{{ item }}/{{ product }}/{{ version }}/.htaccess"
@@ -16,7 +21,7 @@
       when: s.stat is defined and s.stat.exists
       with_items: "{{ www_folders }}"
 
-    - name: Make release folders read-only and owned by roo
+    - name: Make release folders read-only and owned by root
       file:
         path: "{{ item }}/{{ product }}/{{ version }}"
         state: directory
@@ -24,5 +29,29 @@
         group: root
         recurse: true
         mode: 01555
+      when: s.stat is defined and s.stat.exists
+      with_items: "{{ www_folders }}"
+
+    - name: Create minor version symlink
+      file:
+        src: "{{ item }}/{{ product }}/{{ version }}"
+        dest: "{{ item }}/{{ product }}/{{ minorversion }}"
+        state: link
+      when: s.stat is defined and s.stat.exists
+      with_items: "{{ www_folders }}"
+
+    - name: Create major version symlink
+      file:
+        src: "{{ item }}/{{ product }}/{{ version }}"
+        dest: "{{ item }}/{{ product }}/{{ majorversion }}"
+        state: link
+      when: s.stat is defined and s.stat.exists
+      with_items: "{{ www_folders }}"
+
+    - name: Create latest version symlink
+      file:
+        src: "{{ item }}/{{ product }}/{{ version }}"
+        dest: "{{ item }}/{{ product }}/latest"
+        state: link
       when: s.stat is defined and s.stat.exists
       with_items: "{{ www_folders }}"

--- a/release/release-acceptance.yml
+++ b/release/release-acceptance.yml
@@ -2,12 +2,22 @@
 - hosts: idr0-slot3.openmicroscopy.org
   become: true
   tasks:
-    - name: Check that the release component exists
+    - name: Check mandatory variables are defined
+      fail:
+        msg: Please pass 'product' and 'version variables'
+      when: product is not defined and version is not defined
+
+    - name: Check the release component exist
       stat:
-        path: "/uod/idr/www/downloads.openmicroscopy.org/\
-          {{ product }}/{{ version }}/"
+        path: "{{ item }}/{{ product }}/{{ version }}/"
       register: s
-      when: product is defined and version is defined
+      with_items: "{{ www_folders }}"
+
+    - name: Check the release component exist
+      fail:
+        msg: "{{ item }} does not exist"
+      with_items: "{{ s.results }}"
+      when: item.stat is not defined or not item.stat.exists
 
     - name: Define minor and major versions
       set_fact:
@@ -18,7 +28,6 @@
       file:
         path: "{{ item }}/{{ product }}/{{ version }}/.htaccess"
         state: absent
-      when: s.stat is defined and s.stat.exists
       with_items: "{{ www_folders }}"
 
     - name: Make release folders read-only and owned by root
@@ -29,7 +38,6 @@
         group: root
         recurse: true
         mode: 01555
-      when: s.stat is defined and s.stat.exists
       with_items: "{{ www_folders }}"
 
     - name: Create minor version symlink
@@ -37,7 +45,6 @@
         src: "{{ item }}/{{ product }}/{{ version }}"
         dest: "{{ item }}/{{ product }}/{{ minorversion }}"
         state: link
-      when: s.stat is defined and s.stat.exists
       with_items: "{{ www_folders }}"
 
     - name: Create major version symlink
@@ -45,7 +52,6 @@
         src: "{{ item }}/{{ product }}/{{ version }}"
         dest: "{{ item }}/{{ product }}/{{ majorversion }}"
         state: link
-      when: s.stat is defined and s.stat.exists
       with_items: "{{ www_folders }}"
 
     - name: Create latest version symlink
@@ -53,5 +59,4 @@
         src: "{{ item }}/{{ product }}/{{ version }}"
         dest: "{{ item }}/{{ product }}/latest"
         state: link
-      when: s.stat is defined and s.stat.exists
       with_items: "{{ www_folders }}"


### PR DESCRIPTION
## Proposal


This PR proposes to improve the discoverability and maintenance of latest, major and minor versioned URLs for downloads and documentation components via the Ansible release playbook rather than Apache redirects at the moment.

## Changes

This changeset primarily affects the `release-acceptance.yml` playbooks:
- refactor the release folder checks and fail the playbook if either variables are undefined or release folders are missing
- add tasks creating symlinks `x.y`, `x` and `latest` linking the to specified `x.y.z` version for both documentation and downloads unless the version is a pre-release one e.g. 5.5.0-rc1 e.g.



## Testing

Molecule tests have been added to cover the various tasks achieved by the playbook i.e. `.htaccess` removal, chowning/chmoding and symlink creation both in the case of pre-releases as well as full release.

To simplify the functional review, temporary folders were also created using the last OMERO documentation and downloads  under a temporary URL. The playbook was run as `ansible-playbook -K release/release-acceptance.yml -e product=omero-test -e version=5.5.0`. The temporary https://downloads.openmicroscopy.org/omero-test/ and https://docs.openmicroscopy.org/omero-test/ URLs can be reviewed and should contain all versions of the URLs.

## Follow-up tasks

If we agree on using this new scheme, two follow-up of this change might be:

- modify the playbook to allow documentation-only release i.e. allow to pass a release type e.g. `release-acceptance` playbook for a given type of component  e.g. `ansible-playbook -K release/release-acceptance.yml -e product=omero-test -e version=5.5.1 -e release_type=docs`
- update the `latest/<product>{x,x.y}` URLs maintained via Web server to point at the new `<product>/{latest,x,x.y}` URL and reduce our maintenance