### PR TITLE
Install omero-metadata plugin

### DIFF
--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -111,6 +111,7 @@
         name:
         - "omero-cli-duplicate=={{ omero_cli_duplicate_release }}"
         - "omero-cli-render=={{ omero_cli_render_release }}"
+        - "omero-metadata=={{ omero_metadata_release }}"
         state: present
 
     - name: Create a figure scripts directory
@@ -343,6 +344,7 @@
     omero_webtagging_autotag_release: "{{ omero_webtagging_autotag_release_override | default('3.0.2') }}"
     omero_webtagging_tagsearch_release: "{{ omero_webtagging_tagsearch_release_override | default('3.0.3') }}"
     omero_cli_duplicate_release: "{{ omero_cli_duplicate_release_override | default('0.2.0') }}"
+    omero_metadata_release: "{{ omero_metadata_release_overrride | default('0.3.1') }}"
     omero_cli_render_release: "{{ omero_cli_render_release_override | default('0.4.2') }}"
     # The os_system_users_password default is "ome".
     # You may wish to change this variable,


### PR DESCRIPTION
See discussion https://openmicroscopy.slack.com/archives/C1PJHN2D7/p1561048398043900 - the aim here is to have the metadata plugin installed on the outreach machine so that the server can see it. The next step, as described in Slack, will be to test and implement the UI-based server side script in Import scripts > populate metadata to harvest this cli code and thus enable users to easily create tables from csv files, without using elaborate Fiji, R or other scripts/coding.


cc @jburel @will-moore 