### PR TITLE
NSweb default iviewer can be overridden

### DIFF
--- a/templates/omero-web-config-for-webapps.j2
+++ b/templates/omero-web-config-for-webapps.j2
@@ -16,7 +16,7 @@ config append -- omero.web.open_with '["omero_fpbioimage", "fpbioimage_index", {
 config append -- omero.web.apps '"omero_iviewer"'
 config append -- omero.web.open_with '["omero_iviewer", "omero_iviewer_index", {"supported_objects":["images", "dataset", "well"], "script_url": "omero_iviewer/openwith.js", "label": "OMERO.iviewer"}]'
 # set iviewer as a default viewer
-config set -- omero.web.viewer.view omero_iviewer.views.index
+config set -- omero.web.viewer.view {{ omeroweb_default_viewer_override | default('omero_iviewer.views.index') }}
 
 # Autotag
 config append -- omero.web.apps '"omero_webtagging_autotag"'


### PR DESCRIPTION
The default web viewer in templates/omero-web-config-for-webapps.j2 can be overridden on a case-by-case basis