### PR TITLE
Add pip install to demo playbook

### DIFF
--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -165,6 +165,15 @@
       notify:
         - restart omero-web
 
+    - name: Omero.cli plugins | plugin install via pip & pypi
+      become: yes
+      pip:
+        name:
+        - "omero-cli-duplicate=={{ omero_cli_duplicate_release }}"
+        - "omero-cli-metadata=={{ omero_cli_metadata_release }}"
+        - "omero-cli-render=={{ omero_cli_render_release }}"
+        state: present
+
     - name: NGINX - Performance tuning - worker processes
       become: yes
       replace:
@@ -319,6 +328,11 @@
     # Backup folder for PostgreSQL 'folder' format dump
     omero_server_db_dumpdir_parent: /tmp
     omero_server_db_dumpdir_name: nightly-pg_dump_omero.dir
+
+    # Pip versions
+    omero_cli_duplicate_release: "{{ omero_cli_duplicate_release_override | default('0.2.0') }}"
+    omero_cli_render_release: "{{ omero_cli_render_release_override | default('0.4.2') }}"
+    omero_cli_metadata_release: "{{ omero_cli_metadata_release_override | default('0.4.0') }}"
 
     postgresql_version: "9.6"
     filesystem: "xfs"

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -170,8 +170,8 @@
       pip:
         name:
         - "omero-cli-duplicate=={{ omero_cli_duplicate_release }}"
-        - "omero-cli-metadata=={{ omero_cli_metadata_release }}"
         - "omero-cli-render=={{ omero_cli_render_release }}"
+        - "omero-metadata=={{ omero_metadata_release }}"
         state: present
 
     - name: NGINX - Performance tuning - worker processes
@@ -332,7 +332,7 @@
     # Pip versions
     omero_cli_duplicate_release: "{{ omero_cli_duplicate_release_override | default('0.2.0') }}"
     omero_cli_render_release: "{{ omero_cli_render_release_override | default('0.4.2') }}"
-    omero_cli_metadata_release: "{{ omero_cli_metadata_release_override | default('0.4.0') }}"
+    omero_metadata_release: "{{ omero_cli_metadata_release_override | default('0.4.0') }}"
 
     postgresql_version: "9.6"
     filesystem: "xfs"


### PR DESCRIPTION
This is in preparation for the OMERO 5.5.1 release and has been manually performed on pub-omero. A decision needs to be made if we're happy with it in general for the demo servers.

Looking at the diff, I think we're approaching needing a simpler way to do this, e.g.

```
pip install omero-plugins==x.y.z
```

cc: @pwalczysko @sbesson @manics 