### PR TITLE
Postgres new omero db molecule workaround

### DIFF
--- a/k8s/postgres/playbook.yml
+++ b/k8s/postgres/playbook.yml
@@ -2,7 +2,7 @@
 - hosts: ome-k8s-pg-01.openmicroscopy.org
   roles:
 
-  - role: openmicroscopy.postgresql-3
+  - role: ome.postgresql
     postgresql_version: "9.6"
     postgresql_server_listen: "'*'"
     postgresql_databases:

--- a/molecule/omero-training-server/molecule.yml
+++ b/molecule/omero-training-server/molecule.yml
@@ -26,6 +26,10 @@ provisioner:
     group_vars:
       all:
         molecule_test: True
+        # Temporary workaround for
+        # https://forum.image.sc/t/fyi-not-possible-to-create-new-omero-instance-with-latest-postgresql-versions/26929
+        # Only affects new OMERO databases, existing ones should be OK
+        postgresql_package_version: 9.6.13
       docker-hosts:
         omero_server_systemd_require_network: False
         # This should allow docker-in-docker to work

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -98,7 +98,7 @@
       # Defaults overridden in private configuration
       # nginx_version:
 
-    - role: openmicroscopy.postgresql-3
+    - role: ome.postgresql
       #no_log: true
       postgresql_databases:
         - name: omero

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -34,7 +34,7 @@
 
   roles:
 
-    - role: openmicroscopy.postgresql-3
+    - role: ome.postgresql
       postgresql_databases:
       - name: omero
       postgresql_users:

--- a/requirements.yml
+++ b/requirements.yml
@@ -69,9 +69,8 @@
 - src: openmicroscopy.postgresql
   version: 2.0.0
 
-- name: openmicroscopy.postgresql-3
-  src: openmicroscopy.postgresql
-  version: 3.0.1
+- src: ome.postgresql
+  version: 3.2.0
 
 - src: openmicroscopy.postgresql_backup
   version: 0.1.0


### PR DESCRIPTION
Workaround https://forum.image.sc/t/fyi-not-possible-to-create-new-omero-instance-with-latest-postgresql-versions/26929
- Changes `openmicroscopy.postgresql-3` to `ome.postgresql` (existing `openmicroscopy.postgresql` is unchanged)
- Pins the pg version to `9.6.13` in the training-server molecule test. This is the only playbook that has a full OMERO molecule test.

Not yet tested