### PR TITLE
Versioned URLs - part 2

### DIFF
--- a/molecule/release/prepare.yml
+++ b/molecule/release/prepare.yml
@@ -16,15 +16,30 @@
      group: root
      mode: 01555
     with_items: "{{ www_folders }}"
+  - name: Create minor version directory
+    file:
+     path: "{{ item }}/component/3.1"
+     state: directory
+    with_items: "{{ www_folders }}"
   - name: Create minor version redirects
     copy:
      dest: "{{ item }}/component/3.1/.htaccess"
      content: "Redirect 301 /component/3.1 /component/3.1.8"
     with_items: "{{ www_folders }}"
+  - name: Create major version directory
+    file:
+     path: "{{ item }}/component/3"
+     state: directory
+    with_items: "{{ www_folders }}"
   - name: Create major version redirects
     copy:
      dest: "{{ item }}/component/3/.htaccess"
      content: "Redirect 301 /component/3 /component/3.1.8"
+    with_items: "{{ www_folders }}"
+  - name: Create latest version directory
+    file:
+     path: "{{ item }}/component/latest"
+     state: directory
     with_items: "{{ www_folders }}"
   - name: Create latest version redirects
     copy:

--- a/molecule/release/prepare.yml
+++ b/molecule/release/prepare.yml
@@ -16,23 +16,20 @@
      group: root
      mode: 01555
     with_items: "{{ www_folders }}"
-  - name: Create existing minor version symlinks
-    file:
-     src: "{{ item }}/component/3.1.8"
-     dest: "{{ item }}/component/3.1"
-     state: link
+  - name: Create minor version redirects
+    copy:
+     dest: "{{ item }}/component/3.1/.htaccess"
+     content: "Redirect 301 /component/3.1 /component/3.1.8"
     with_items: "{{ www_folders }}"
-  - name: Create existing major version symlinks
-    file:
-     src: "{{ item }}/component/3.1.8"
-     dest: "{{ item }}/component/3"
-     state: link
+  - name: Create major version redirects
+    copy:
+     dest: "{{ item }}/component/3/.htaccess"
+     content: "Redirect 301 /component/3 /component/3.1.8"
     with_items: "{{ www_folders }}"
-  - name: Create existing latest version symlinks
-    file:
-     src: "{{ item }}/component/3.1.8"
-     dest: "{{ item }}/component/latest"
-     state: link
+  - name: Create latest version redirects
+    copy:
+     dest: "{{ item }}/component/latest/.htaccess"
+     content: "Redirect 301 /component/latest /component/3.1.8"
     with_items: "{{ www_folders }}"
   - name: Create new release components
     file:

--- a/molecule/release/tests/test_default.py
+++ b/molecule/release/tests/test_default.py
@@ -22,24 +22,27 @@ def test_permissions(host, base_folder):
 
 
 @pytest.mark.parametrize('base_folder', [DOWNLOADS_URL, DOCS_URL])
-def test_symlinks(host, base_folder):
+def test_redirects(host, base_folder):
     v = host.ansible.get_variables()
     hostname = host.backend.get_hostname()
-    f = host.file('%s/component/3.2' % base_folder)
+    f = host.file('%s/component/3.2/.htaccess' % base_folder)
     if hostname == 'release':
-        assert f.is_symlink
-        assert f.linked_to == '%s/component/%s' % (base_folder, v['version'])
+        assert f.exists
+        assert f.content == (
+            'Redirect 301 /component/3.2 /component/%s' % v['version'])
     elif hostname == 'prelease':
         assert not f.exists
-    f = host.file('%s/component/3' % base_folder)
-    assert f.is_symlink
+    f = host.file('%s/component/3/.htaccess' % base_folder)
+    assert f.exists
     if hostname == 'release':
-        assert f.linked_to == '%s/component/%s' % (base_folder, v['version'])
+        assert f.content == (
+            'Redirect 301 /component/3 /component/%s' % v['version'])
     elif hostname == 'prelease':
-        assert f.linked_to == '%s/component/3.1.8' % base_folder
+        assert f.content == 'Redirect 301 /component/3 /component/3.1.8'
     f = host.file('%s/component/latest' % base_folder)
-    assert f.is_symlink
+    assert f.exists
     if hostname == 'release':
-        assert f.linked_to == '%s/component/%s' % (base_folder, v['version'])
+        assert f.content == (
+            'Redirect 301 /component/latest /component/%s' % v['version'])
     elif hostname == 'prelease':
-        assert f.linked_to == '%s/component/3.1.8' % base_folder
+        assert f.content == 'Redirect 301 /component/latest /component/3.1.8'

--- a/molecule/release/tests/test_default.py
+++ b/molecule/release/tests/test_default.py
@@ -39,7 +39,7 @@ def test_redirects(host, base_folder):
             'Redirect 301 /component/3 /component/%s' % v['version'])
     elif hostname == 'prelease':
         assert f.content == 'Redirect 301 /component/3 /component/3.1.8'
-    f = host.file('%s/component/latest' % base_folder)
+    f = host.file('%s/component/latest/.htaccess' % base_folder)
     assert f.exists
     if hostname == 'release':
         assert f.content == (

--- a/release/release-acceptance.yml
+++ b/release/release-acceptance.yml
@@ -44,26 +44,47 @@
         mode: 01555
       with_items: "{{ www_folders }}"
 
-    - name: Create minor version symlink
+    - name: Create minor version directory
       file:
-        src: "{{ item }}/{{ product }}/{{ version }}"
-        dest: "{{ item }}/{{ product }}/{{ minorversion }}"
-        state: link
+        path: "{{ item }}/{{ product }}/{{ minorversion }}"
+        state: directory
       with_items: "{{ www_folders }}"
       when: not prerelease
 
-    - name: Create major version symlink
-      file:
-        src: "{{ item }}/{{ product }}/{{ version }}"
-        dest: "{{ item }}/{{ product }}/{{ majorversion }}"
-        state: link
+    - name: Create minor version redirects
+      copy:
+        dest: "{{ item }}/{{ product }}/{{ minorversion }}/.htaccess"
+        content: "Redirect 301 /{{ product }}/{{ minorversion }} \
+          /{{ product }}/{{ version }}"
       with_items: "{{ www_folders }}"
       when: not prerelease
 
-    - name: Create latest version symlink
+    - name: Create minor version directory
       file:
-        src: "{{ item }}/{{ product }}/{{ version }}"
-        dest: "{{ item }}/{{ product }}/latest"
-        state: link
+        path: "{{ item }}/{{ product }}/{{ majorversion }}"
+        state: directory
+      with_items: "{{ www_folders }}"
+      when: not prerelease
+
+    - name: Create major version redirects
+      copy:
+        dest: "{{ item }}/{{ product }}/{{ majorversion }}/.htaccess"
+        content: "Redirect 301 /{{ product }}/{{ majorversion }} \
+          /{{ product }}/{{ version }}"
+      with_items: "{{ www_folders }}"
+      when: not prerelease
+
+    - name: Create latest version directory
+      file:
+        path: "{{ item }}/{{ product }}/latest"
+        state: directory
+      with_items: "{{ www_folders }}"
+      when: not prerelease
+
+    - name: Create latest version redirect
+      copy:
+        dest: "{{ item }}/{{ product }}/latest/.htaccess"
+        content: "Redirect 301 /{{ product }}/latest \
+          /{{ product }}/{{ version }}"
       with_items: "{{ www_folders }}"
       when: not prerelease


### PR DESCRIPTION
Follow-up of #177. A main issue associated with the new URLs aliases (latest, minor, major) associated with every release is the absence of redirection to the canonical version URL. A typical usage is consumers relying this redirection to programmatically retrieve the latest version of a component.

This PR updates the logic for creating these aliases and creates `{latest,minor,major}/.htaccess` files redirecting to the canonical versioned URLs rather than symlinks transparently served by the Web server.

As previously, an (UoD internal-only) test of this PR has been created under http://downloads.openmicroscopy.org/omero-test/:

- the 5.4 alias has been created using the previous iteration and should serve the 5.4 content but not redirect
- the 5.5, 5 and latest aliases have been created by this PR (after manually deleting the symlinks) and should serve the 5.5 content as well as redirect the URL

The Molecule tests have also been updated to test the new logic.