### PR TITLE
Ansible OMERO Galaxy roles: switch to new namespace

### DIFF
--- a/jupyterhub/playbook.yml
+++ b/jupyterhub/playbook.yml
@@ -164,7 +164,7 @@
 
   # This is needed because we attempt to stop/start nginx in certbot, so
   # it needs to be installed even if it's not used
-  - role: openmicroscopy.nginx
+  - role: ome.nginx
 
   # Lets encrypt with automatic renewal
   # This will stop nginx when the certificate is first created
@@ -188,7 +188,7 @@
     #   rm -rf /etc/letsencrypt/*
     when: https_letsencrypt_enabled | default(False)
 
-  - role: openmicroscopy.nginx-proxy
+  - role: ome.nginx_proxy
     #nginx_proxy_force_ssl: True
     nginx_proxy_ssl: True
     nginx_proxy_ssl_certificate: "{{ (https_letsencrypt_enabled | default(False)) | ternary(https_letsencrypt_cert_path + '/fullchain.pem', ssl_certificate_public_path) }}"

--- a/molecule/omero-training-server/molecule.yml
+++ b/molecule/omero-training-server/molecule.yml
@@ -26,6 +26,7 @@ provisioner:
     group_vars:
       all:
         molecule_test: True
+        postgresql_version: "9.6"
         # Temporary workaround for
         # https://forum.image.sc/t/fyi-not-possible-to-create-new-omero-instance-with-latest-postgresql-versions/26929
         # Only affects new OMERO databases, existing ones should be OK

--- a/nightshade-webclients.yml
+++ b/nightshade-webclients.yml
@@ -16,10 +16,10 @@
     - role: openmicroscopy.ssl-certificate
       # Configuration for this role in `vars`
 
-    - role: openmicroscopy.nginx
+    - role: ome.nginx
 
     # OMERO.web configuration in host_vars in different repository
-    - role: openmicroscopy.omero-web
+    - role: ome.omero_web
       omero_web_release: "{{ omero_web_release_version }}"
       omero_web_systemd_limit_nofile: 16384
 
@@ -42,7 +42,7 @@
         - "omero-webtagging-tagsearch=={{ omero_webtagging_tagsearch_release }}"
         editable: False
         state: present
-        # variable comes from role openmicroscopy.omero-web
+        # variable comes from role ome.omero_web
         virtualenv: "{{ omero_web_basedir }}/venv"
         virtualenv_site_packages: yes
       notify:

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -94,7 +94,7 @@
       lvm_lvfilesystem: "{{ filesystem }}"
       lvm_shrink: False
 
-    - role: openmicroscopy.nginx
+    - role: ome.nginx
       # Defaults overridden in private configuration
       # nginx_version:
 
@@ -108,7 +108,7 @@
         databases:
           - omero
 
-    - role: openmicroscopy.omero-server
+    - role: ome.omero_server
       # Defaults overridden in private configuration
       # omero_server_release:
       # omero_server_dbuser:
@@ -117,13 +117,13 @@
       omero_server_dbname: omero
       omero_server_systemd_limit_nofile: 16384
 
-    - role: openmicroscopy.omero-web
+    - role: ome.omero_web
       # Defaults overridden in private configuration
       # omero_web_release:
       omero_web_systemd_limit_nofile: 16384
 
     # This role only works on OMERO 5.3+
-    - role: openmicroscopy.omero-user
+    - role: ome.omero_user
       no_log: true
       omero_user_bin_omero: /opt/omero/server/OMERO.server/bin/omero
       omero_user_system: omero-server
@@ -159,7 +159,7 @@
         - "django-cors-headers=={{ django_cors_headers_release }}"
         editable: False
         state: present
-        # variable comes from role openmicroscopy.omero-web
+        # variable comes from role ome.omero_web
         virtualenv: "{{ omero_web_basedir }}/venv"
         virtualenv_site_packages: yes
       notify:

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -96,7 +96,7 @@
 
     # Note - had to have these set to `install-mock` to progress role
     # installation before changing config to restored DB from other system.
-    - role: openmicroscopy.omero-server
+    - role: ome.omero_server
       omero_server_release: 5.5.0
       # install-mock set for inital provision, then playbook re-run with correct accounts.
       #omero_server_dbuser: install-mock

--- a/omero/omero-monitoring-agents.yml
+++ b/omero/omero-monitoring-agents.yml
@@ -12,7 +12,7 @@
   # For restart handlers
   - role: ome.omero_common
 
-  - role: openmicroscopy.omero_prometheus_exporter
+  - role: ome.omero_prometheus_exporter
     omero_prometheus_exporter_omero_user: "{{ secret_omero_prometheus_exporter_omero_user | default('root') }}"
     omero_prometheus_exporter_omero_password: "{{ secret_omero_prometheus_exporter_omero_password | default('omero') }}"
 
@@ -31,7 +31,7 @@
 
   roles:
 
-  - role: openmicroscopy.omero-web-django-prometheus
+  - role: ome.omero_web_django_prometheus
 
 
 # NOTE: This assumes omero-web.conf is present and includes

--- a/omero/omero-monitoring-agents.yml
+++ b/omero/omero-monitoring-agents.yml
@@ -43,7 +43,7 @@
   - role: openmicroscopy.prometheus-node
 
   # Autodetect whether selinux is enabled
-  - role: openmicroscopy.selinux-utils
+  - role: ome.selinux_utils
 
   tasks:
 

--- a/omero/omero-monitoring-agents.yml
+++ b/omero/omero-monitoring-agents.yml
@@ -10,7 +10,7 @@
     prometheus_postgres_dbname: omero
 
   # For restart handlers
-  - role: openmicroscopy.omero-common
+  - role: ome.omero_common
 
   - role: openmicroscopy.omero_prometheus_exporter
     omero_prometheus_exporter_omero_user: "{{ secret_omero_prometheus_exporter_omero_user | default('root') }}"

--- a/omero/omero-web-patch-settings.yml
+++ b/omero/omero-web-patch-settings.yml
@@ -5,7 +5,7 @@
 
   roles:
     # Needed for handlers
-    - role: openmicroscopy.omero-common
+    - role: ome.omero_common
 
   tasks:
 

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -47,9 +47,9 @@
 
     - role: openmicroscopy.nfs-mount
 
-    - role: openmicroscopy.omero-server
+    - role: ome.omero_server
 
-    - role: openmicroscopy.omero-web
+    - role: ome.omero_web
       # omero_web_config_set:
 
     - role: openmicroscopy.iptables-raw

--- a/requirements.yml
+++ b/requirements.yml
@@ -33,7 +33,7 @@
   version: 1.1.1
 
 - src: ome.nginx_proxy
-  version: 1.9.0
+  version: 1.11.0
 
 - src: openmicroscopy.nfs-mount
   version: 1.0.0
@@ -47,8 +47,8 @@
 - src: ome.basedeps
   version: 1.1.0
 
-- src: openmicroscopy.omero_prometheus_exporter
-  version: 0.2.0
+- src: ome.omero_prometheus_exporter
+  version: 0.2.1
 
 - src: ome.omero_python_deps
   version: 2.0.1
@@ -62,9 +62,8 @@
 - src: ome.omero_web
   version: 2.0.2
 
-- name: openmicroscopy.omero-web-django-prometheus
-  src: https://github.com/openmicroscopy/ansible-role-omero-web-django-prometheus/archive/0.2.0.tar.gz
-  version: 0.2.0
+- src: ome.omero_web_django_prometheus
+  version: 0.2.1
 
 - src: openmicroscopy.lvm-partition
   version: 1.1.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -13,11 +13,11 @@
 - src: openmicroscopy.docker
   version: 3.0.0
 
-- src: openmicroscopy.ice
-  version: 2.1.1
+- src: ome.ice
+  version: 3.0.0
 
-- src: openmicroscopy.java
-  version: 2.0.1
+- src: ome.java
+  version: 2.0.3
 
 - name: openmicroscopy.iptables-raw
   src: https://github.com/openmicroscopy/ansible-role-iptables-raw/archive/0.2.0.tar.gz
@@ -29,35 +29,38 @@
 - name: openmicroscopy.network
   version: 1.1.2
 
-- src: openmicroscopy.nginx
-  version: 1.1.0
+- src: ome.nginx
+  version: 1.1.1
 
-- src: openmicroscopy.nginx-proxy
+- src: ome.nginx_proxy
   version: 1.9.0
 
 - src: openmicroscopy.nfs-mount
   version: 1.0.0
 
-- src: openmicroscopy.omego
-  version: 0.1.1
+- src: ome.omego
+  version: 0.1.3
 
-- src: openmicroscopy.omero-common
+- src: ome.omero_common
   version: 0.1.0
+
+- src: ome.basedeps
+  version: 1.1.0
 
 - src: openmicroscopy.omero_prometheus_exporter
   version: 0.2.0
 
-- src: openmicroscopy.omero-python-deps
-  version: 1.1.0
-
-- src: openmicroscopy.omero-server
-  version: 2.0.5
-
-- src: openmicroscopy.omero-user
-  version: 0.1.1
-
-- src: openmicroscopy.omero-web
+- src: ome.omero_python_deps
   version: 2.0.1
+
+- src: ome.omero_server
+  version: 2.0.6
+
+- src: ome.omero_user
+  version: 0.1.2
+
+- src: ome.omero_web
+  version: 2.0.2
 
 - name: openmicroscopy.omero-web-django-prometheus
   src: https://github.com/openmicroscopy/ansible-role-omero-web-django-prometheus/archive/0.2.0.tar.gz
@@ -91,7 +94,7 @@
   src: openmicroscopy.ansible-role-prometheus-postgres
   version: 0.2.0
 
-- name: openmicroscopy.selinux-utils
+- name: ome.selinux_utils
   version: 1.0.3
 
 - src: openmicroscopy.ssl-certificate

--- a/site.yml
+++ b/site.yml
@@ -26,3 +26,9 @@
 
 # https://outreach-analysis.openmicroscopy.org backup JupyterHub server
 - include: jupyterhub/playbook.yml
+
+# https://www.openmicroscopy.org/
+- include: www/playbook.yml
+
+# OME proxied service
+- include: web-proxy/playbook.yml

--- a/web-proxy/playbook.yml
+++ b/web-proxy/playbook.yml
@@ -18,4 +18,4 @@
     lvm_lvsize: "{{ varlog_size }}"
     lvm_lvfilesystem: "{{ root_filesystem }}"
   - role: openmicroscopy.ssl-certificate
-  - role: openmicroscopy.nginx-proxy
+  - role: ome.nginx_proxy

--- a/www/www-deploy.yml
+++ b/www/www-deploy.yml
@@ -4,7 +4,7 @@
 
   roles:
     - role: openmicroscopy.ssl-certificate
-    - role: openmicroscopy.nginx-proxy
+    - role: ome.nginx_proxy
       tags: nginxconf
 
   vars:


### PR DESCRIPTION
See also https://github.com/ome/ansible-example-omero-onenode/pull/1 and https://github.com/IDR/deployment/pull/194

Switch all roles associated with the installation of OMERO.server and OMERO.web to use the roles published under the Galaxy `ome` namespace (following the deprecation of the `openmicroscopy` namespace).

Most roles are bumped to the next patch release which should be harmless. Only exceptions are `ome.ice 2.1.1 -> 3.0.0` (drop support for Ice 3.5) and `ome.omero_python_deps 1.1.0 -> 2.0.1` (remove Scipy)

To be run in check-mode against:

- [x] ome-dundeeomero

   ```
   (ansible) sbesson@ls30630:prod (master) $ ansible-playbook -KC playbooks/ome-dundeeomero.yml 
   ...
   PLAY RECAP *********************************************************************************************************************************************
   ome-dundeeomero.openmicroscopy.org : ok=75   changed=3    unreachable=0    failed=0   
   ```

   Changes related to pip in check-mode and the figure script

- [x] ome-demoservers

   ```
   (ansible) sbesson@ls30630:prod (master) $ ansible-playbook -KC playbooks/ome-demoserver.yml
   ...
   PLAY RECAP *********************************************************************
   ns-web-pub.openmicroscopy.org : ok=4    changed=0    unreachable=0    failed=0   
   ns-web.openmicroscopy.org  : ok=4    changed=0    unreachable=0    failed=0   
   ome-demoserver.openmicroscopy.org : ok=137  changed=11   unreachable=0    failed=0   
   pub-omero.openmicroscopy.org : ok=140  changed=10   unreachable=0    failed=0 
   ```
  
  Changes are related to Nginx, pip/virtualenv and the figure scripts

- [X] ns-webclients

   ```
   (ansible) sbesson@ls30630:prod (master) $ ansible-playbook -KC playbooks/nightshade-webclients.yml 
   ...
   PLAY RECAP *********************************************************************************************************************************************
   ns-web-pub.openmicroscopy.org : ok=74   changed=7    unreachable=0    failed=0   
   ns-web.openmicroscopy.org  : ok=74   changed=7    unreachable=0    failed=0   
   ome-demoserver.openmicroscopy.org : ok=4    changed=0    unreachable=0    failed=0   
   pub-omero.openmicroscopy.org : ok=4    changed=0    unreachable=0    failed=0 
   ```
  
  Changes are related to Nginx, pip/virtualenv in check-mode

- [x] outreach
 
  ```
   (ansible) sbesson@ls30630:prod (master) $ ansible-playbook -KC playbooks/omero/training-server/playbook.yml 
   ...
   PLAY RECAP *********************************************************************************************************************************************
   outreach.openmicroscopy.org : ok=131  changed=14   unreachable=0    failed=0   
  ```

   Changes in pip/virtualenv (check-mode), and scripts download