### PR TITLE
www phpbbforum: fix typo in style (missing ,)

### DIFF
--- a/www/www-static.yml
+++ b/www/www-static.yml
@@ -33,7 +33,15 @@
     become: yes
     blockinfile:
       block: |
-        form, ul.linklist.rightside, .quick-login, .buttons, #jumpbox~h3, #jumpbox~p .headerspace~h3, .headerspace~p, ul.linklist li.rightside {
+        form,
+        .quick-login,
+        .buttons,
+        #jumpbox~h3,
+        #jumpbox~p,
+        .headerspace~h3,
+        .headerspace~p,
+        ul.linklist.rightside,
+        ul.linklist li.rightside {
             display: none;
         }
       marker: "/* {mark} ANSIBLE MANAGED BLOCK */"


### PR DESCRIPTION
There was a missing `,` between `#jumpbox~p .headerspace~h3` in https://github.com/ome/prod-playbooks/pull/188 which meant the online users section of the footer wasn't fully hidden.

Deployed to ome-www-dev