### PR TITLE
Dropbox

### DIFF
--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -355,7 +355,7 @@
     omero_server_config_set:
       #omero.fs.importUsers: "fm1"
       omero.fs.watchDir: "/home/DropBox"
-      omero.fs.importArgs: "-T Dataset:@name:from-Dropbox"
+      omero.fs.importArgs: "-T Dataset:name:from-Dropbox"
       omero.db.poolsize: 60
       omero.jvmcfg.percent.blitz: 50
       omero.jvmcfg.percent.indexer: 20

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -355,7 +355,7 @@
     omero_server_config_set:
       #omero.fs.importUsers: "fm1"
       omero.fs.watchDir: "/home/DropBox"
-      omero.fs.importArgs: "-T Dataset:name:from-Dropbox"
+      omero.fs.importArgs: "-T \"regex:^.*/(?<Container1>.*?)\""
       omero.db.poolsize: 60
       omero.jvmcfg.percent.blitz: 50
       omero.jvmcfg.percent.indexer: 20


### PR DESCRIPTION
Change the configuration of dropbox so that it uses regex. 
Originally, the config was the same for all users, and also, the DropBox was creating a new folder for every drop even for the same user.
This was to circumvent the (now fixed) bug with import into RO or RA group where multiple Datasets of the same name already exist.
As this bug is fixed, this PR adds more fancy regex in line with the work on the g.doc for DropBox, see last part of https://docs.google.com/document/d/1ZWBZZWHK7ZUxK48QrT_PcbVB6w72uhhtZ3atJrMD5KQ/edit#

This was run and tested on outreach.

The regex is supposed (and as tested is really doing) to do following: The name of the newly created Dataset is taken from the lowest containing folder inside the DropBox directory.

cc @manics @sbesson @jburel @joshmoore 