### PR TITLE
Remove fm users and their dropbox folders

### DIFF
--- a/molecule/omero-training-server/tests/test_default.py
+++ b/molecule/omero-training-server/tests/test_default.py
@@ -25,7 +25,7 @@ def test_service_running_and_enabled(Service, name):
 
 
 def test_omero_login(host):
-    with host.sudo('fm1'):
+    with host.sudo('importer1'):
         host.check_output(
             '/opt/omero/server/OMERO.server/bin/omero '
             'login -C -s localhost -u root -w omero')

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -255,15 +255,6 @@
       notify:
       - restart omero-web
 
-    - name: Add facility manager operating system users
-      become: true
-      user:
-       name: "{{ item }}"
-       state: present
-       groups: "{{ omero_server_system_managedrepo_group }}"
-       password: "{{ os_system_users_password }}"
-      with_sequence: start=1 end=40 format=fm%d
-
     - name: Add operating system user "importer1"
       become: true
       user:
@@ -271,16 +262,6 @@
        state: present
        groups: "{{ omero_server_system_managedrepo_group }}"
        password: "{{ os_system_users_password }}"
-
-    - name: Add DropBox folders for fm1 through fm40
-      become: true
-      file:
-        path: /home/DropBox/{{ item }}
-        state: directory
-        mode: 0755
-        owner: "{{ item }}"
-        group: "{{ item }}"
-      with_sequence: start=1 end=40 format=fm%d
 
     - name: Allow managed repo group to login
       become: yes


### PR DESCRIPTION
When writing the g.doc about DropBox, I realized that we have quite a few redundant users and DropBox folders on outreach.

This PR is removing the corresponding bits from the playbook.

Also, I will remove manually the already existing DropBox folders on outreach.
This includes a "falso" ``/OMERO/DropBox`` folder, which should have never existed.

cc @jburel @joshmoore @manics @sbesson 


Edit 
Removed the redundant folder from Outreach server as indicated in the header. Dropbox on outreach still works.