### PR TITLE
Remove Kymo and Kymo Analysis from workshop folder

### DIFF
--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -154,26 +154,6 @@
         group: "omero-server"
         force: yes
 
-    - name: Download the Kymograph.py script
-      become: yes
-      get_url:
-        url: https://raw.githubusercontent.com/ome/training-scripts/v{{ ome_training_scripts_release }}/practical/python/server/Kymograph.py
-        dest: /opt/omero/server/OMERO.server/lib/scripts/omero/workshop_scripts/Kymograph.py
-        mode: 0755
-        owner: "omero-server"
-        group: "omero-server"
-        force: yes
-
-    - name: Download the Kymograph_Analysis.py script
-      become: yes
-      get_url:
-        url: https://raw.githubusercontent.com/ome/training-scripts/v{{ ome_training_scripts_release }}/practical/python/server/Kymograph_Analysis.py
-        dest: /opt/omero/server/OMERO.server/lib/scripts/omero/workshop_scripts/Kymograph_Analysis.py
-        mode: 0755
-        owner: "omero-server"
-        group: "omero-server"
-        force: yes
-
     - name: Download the simple_frap.py script
       become: yes
       get_url:


### PR DESCRIPTION
the dedicated Workshop scripts subfolder contains a duplication of the two scripts, Kymograph and Kymograph analysis. This was because the mainline scripts of the same names were not working properly.

Now, we have the mainline scripts released (checked that they work properly on outreach).
Thus, removing the duplicates in the Workshop scripts folder from the playbook.

The playbook was run successfully for outreach server. 

cc @sbesson @manics @will-moore 