### PR TITLE
Use ome.ssl_certificate role

### DIFF
--- a/jupyterhub/playbook.yml
+++ b/jupyterhub/playbook.yml
@@ -206,6 +206,14 @@
       read_timeout: 86400
       host_header: "$host"
 
+  handlers:
+    - name: reload nginx
+      listen: ssl certificate changed
+      become: true
+      service:
+        name: nginx
+        state: reloaded
+
   vars:
     https_certificate_domain: outreach-analysis.openmicroscopy.org
     # This must match the expectations of certbot, do not change this:

--- a/jupyterhub/playbook.yml
+++ b/jupyterhub/playbook.yml
@@ -159,7 +159,7 @@
 
   roles:
 
-  - role: openmicroscopy.ssl-certificate
+  - role: ome.ssl_certificate
     when: not (https_letsencrypt_enabled | default(False))
 
   # This is needed because we attempt to stop/start nginx in certbot, so

--- a/legacy/ssl-deploy.yml
+++ b/legacy/ssl-deploy.yml
@@ -7,7 +7,7 @@
 # openmicroscopy.org wildcard
 - hosts: legacy-ssl-org-wildcard
   roles:
-  - role: openmicroscopy.ssl-certificate
+  - role: ome.ssl_certificate
     # See private vars for certificate content
     # Server path to SSL public certificate
     ssl_certificate_public_path: /etc/pki/tls/certs/star_openmicroscopy_org.crt

--- a/nightshade-webclients.yml
+++ b/nightshade-webclients.yml
@@ -13,7 +13,7 @@
       lvm_lvsize: "{{ provision_rootsize }}"
       lvm_lvfilesystem: "{{ provision_root_filesystem }}"
 
-    - role: openmicroscopy.ssl-certificate
+    - role: ome.ssl_certificate
       # Configuration for this role in `vars`
 
     - role: ome.nginx

--- a/nightshade-webclients.yml
+++ b/nightshade-webclients.yml
@@ -14,7 +14,6 @@
       lvm_lvfilesystem: "{{ provision_root_filesystem }}"
 
     - role: ome.ssl_certificate
-      # Configuration for this role in `vars`
 
     - role: ome.nginx
 
@@ -27,6 +26,15 @@
     # checking `is server deployed in Dundee/SLS` is checking for the SLS nameservers.
     - role: openmicroscopy.system-monitor-agent
       when: "'10.1.255.216' in ansible_dns.nameservers"
+
+  handlers:
+    - name: reload nginx
+      listen: ssl certificate changed
+      become: true
+      service:
+        name: nginx
+        state: reloaded
+
 
   post_tasks:
 

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -141,7 +141,7 @@
         password: "{{ secret_omero_web_public_password | default('public') }}"
         groups: "--group-name public"
 
-    - role: openmicroscopy.ssl-certificate
+    - role: ome.ssl_certificate
       tags: ssl
       # Configuration for this role in `vars`
 

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -143,7 +143,14 @@
 
     - role: ome.ssl_certificate
       tags: ssl
-      # Configuration for this role in `vars`
+
+  handlers:
+    - name: reload web server
+      listen: ssl certificate changed
+      become: true
+      service:
+        name: nginx
+        state: reloaded
 
   post_tasks:
 

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -121,7 +121,14 @@
       omero_server_system_user_manage: False
 
     - role: ome.ssl_certificate
-      # Configuration for this role in `vars`
+
+  handlers:
+    - name: reload nginx
+      listen: ssl certificate changed
+      become: true
+      service:
+        name: nginx
+        state: reloaded
 
   post_tasks:
     - name: NGINX - enable service / start on boot

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -120,7 +120,7 @@
       - gpfs.service
       omero_server_system_user_manage: False
 
-    - role: openmicroscopy.ssl-certificate
+    - role: ome.ssl_certificate
       # Configuration for this role in `vars`
 
   post_tasks:

--- a/requirements.yml
+++ b/requirements.yml
@@ -96,8 +96,8 @@
 - name: ome.selinux_utils
   version: 1.0.3
 
-- src: openmicroscopy.ssl-certificate
-  version: 0.2.2
+- src: ome.ssl_certificate
+  version: 0.3.2
 
 - src: openmicroscopy.sudoers
   version: 1.0.0

--- a/web-proxy/playbook.yml
+++ b/web-proxy/playbook.yml
@@ -19,3 +19,11 @@
     lvm_lvfilesystem: "{{ root_filesystem }}"
   - role: ome.ssl_certificate
   - role: ome.nginx_proxy
+
+  handlers:
+    - name: reload nginx
+      listen: ssl certificate changed
+      become: true
+      service:
+        name: nginx
+        state: reloaded

--- a/web-proxy/playbook.yml
+++ b/web-proxy/playbook.yml
@@ -17,5 +17,5 @@
     lvm_lvmount: /var/log
     lvm_lvsize: "{{ varlog_size }}"
     lvm_lvfilesystem: "{{ root_filesystem }}"
-  - role: openmicroscopy.ssl-certificate
+  - role: ome.ssl_certificate
   - role: ome.nginx_proxy

--- a/www/www-deploy.yml
+++ b/www/www-deploy.yml
@@ -3,7 +3,7 @@
 - hosts: www
 
   roles:
-    - role: openmicroscopy.ssl-certificate
+    - role: ome.ssl_certificate
     - role: ome.nginx_proxy
       tags: nginxconf
 

--- a/www/www-deploy.yml
+++ b/www/www-deploy.yml
@@ -7,6 +7,14 @@
     - role: ome.nginx_proxy
       tags: nginxconf
 
+  handlers:
+    - name: reload nginx
+      listen: ssl certificate changed
+      become: true
+      service:
+        name: nginx
+        state: reloaded
+
   vars:
     nginx_proxy_worker_processes: "{{ ((ansible_processor_count * ansible_processor_cores) / 2) |round|int }}"
     nginx_proxy_worker_connections: 65000


### PR DESCRIPTION
- switches from the deprecated `openmicroscopy.ssl-certificate` to `ome.ssl_certificate`
- updates playbooks to consume the new role
- defines handlers reloading the nginx server when the SSL certificate has changed