### PR TITLE
Review requirements.yml and use new OME Galaxy roles across the board

### DIFF
--- a/bootstrap/playbook.yml
+++ b/bootstrap/playbook.yml
@@ -3,15 +3,15 @@
 - hosts: omedev
   roles:
 
-  - role: openmicroscopy.network
+  - role: ome.network
 
-  - role: openmicroscopy.lvm-partition
+  - role: ome.lvm_partition
     lvm_lvname: var_log
     lvm_lvmount: /var/log
     lvm_lvsize: 4g
     lvm_lvfilesystem: xfs
     lvm_vgname: VolGroup00
-  - role: openmicroscopy.lvm-partition
+  - role: ome.lvm_partition
     lvm_lvname: root
     lvm_lvmount: /
     lvm_lvsize: 100%FREE
@@ -19,16 +19,16 @@
     lvm_vgname: VolGroup00
     lvm_shrink: False
 
-  - role: openmicroscopy.sudoers
+  - role: ome.sudoers
     sudoers_individual_commands:
     - user: "%omedev"
       become: ALL
       command: "NOPASSWD: ALL"
 
-  - role: openmicroscopy.upgrade-distpackages
+  - role: ome.upgrade_distpackages
     upgrade_distpackages_reboot_kernel: True
 
 
 - hosts: vlan-10ge-servers
   roles:
-  - role: openmicroscopy.network
+  - role: ome.network

--- a/jupyterhub/playbook.yml
+++ b/jupyterhub/playbook.yml
@@ -7,7 +7,7 @@
 
   roles:
 
-  - role: openmicroscopy.docker
+  - role: ome.docker
     docker_additional_options:
       # WARNING: This disables the default docker network forwarding rules
       # so we can restrict outgoinng connections from JupyterHub servers,
@@ -43,7 +43,7 @@
       Spawner.mem_limit: 2G
 
   # Setup up iptables to restrict anonymous jupyterhub users
-  - role: openmicroscopy.iptables-raw
+  - role: ome.iptables_raw
 
   tasks:
 
@@ -169,7 +169,7 @@
   # Lets encrypt with automatic renewal
   # This will stop nginx when the certificate is first created
   # For renewals we will configure Nginx to server the challenge
-  - role: openmicroscopy.certbot
+  - role: ome.certbot
     become: yes
     certbot_create_if_missing: yes
     certbot_admin_email: sysadmin@openmicroscopy.org

--- a/k8s/bootstrap/playbook.yml
+++ b/k8s/bootstrap/playbook.yml
@@ -1,4 +1,4 @@
 ---
 - hosts: vlan-10ge-servers
   roles:
-  - role: openmicroscopy.network
+  - role: ome.network

--- a/k8s/postgres/playbook.yml
+++ b/k8s/postgres/playbook.yml
@@ -19,10 +19,10 @@
       user: idr-redmine
       address: "{{ idr_redmine_postgres_auth_ip | default('0.0.0.0/0') }}"
 
-  - role: openmicroscopy.nfs-mount
+  - role: ome.nfs_mount
     # Parameters for this role are internal
 
-  - role: openmicroscopy.postgresql_backup
+  - role: ome.postgresql_backup
     postgresql_backup_dir: /mnt/backups/
     postgresql_backup_filename_format: "{{ ansible_hostname }}-%a.pgdump"
     postgresql_backup_minimum_expected_size: 100000

--- a/k8s/prerequisites/playbook.yml
+++ b/k8s/prerequisites/playbook.yml
@@ -2,4 +2,4 @@
 - hosts: kubernetes-lochy-k8s
   roles:
   # No mounts are configured, this just installs required packages
-  - role: openmicroscopy.nfs-mount
+  - role: ome.nfs_mount

--- a/nightshade-webclients.yml
+++ b/nightshade-webclients.yml
@@ -5,7 +5,7 @@
   roles:
 
     # Root LV Size
-    - role: openmicroscopy.lvm-partition
+    - role: ome.lvm_partition
       tags: lvm
       lvm_lvname: "{{ provision_root_lvname }}"
       lvm_vgname: "{{ provision_root_vgname }}"
@@ -24,7 +24,7 @@
 
     # Now OME are using RHEL without Spacewalk, the current best-method of
     # checking `is server deployed in Dundee/SLS` is checking for the SLS nameservers.
-    - role: openmicroscopy.system-monitor-agent
+    - role: ome.system_monitor_agent
       when: "'10.1.255.216' in ansible_dns.nameservers"
 
   handlers:

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -50,12 +50,12 @@
   roles:
     # Now OME are using RHEL without Spacewalk, the current best-method of
     # checking `is server deployed in Dundee/SLS` is checking for the SLS nameservers.
-    - role: openmicroscopy.system-monitor-agent
+    - role: ome.system_monitor_agent
       tags: monitoring
       when: "'10.1.255.216' in ansible_dns.nameservers"
 
     # Disk Layout - PostgreSQL | data dir on separate VG (SSD)
-    - role: openmicroscopy.lvm-partition
+    - role: ome.lvm_partition
       tags: lvm
       lvm_lvname: pgdata
       lvm_vgname: "{{ provision_postgres_vgname }}"
@@ -65,7 +65,7 @@
       lvm_shrink: False
 
     # Disk Layout - OMERO | VG and LV (separate disk) for Binary Repository
-    - role: openmicroscopy.lvm-partition
+    - role: ome.lvm_partition
       tags: lvm
       lvm_lvname: datadir
       lvm_vgname: "{{ provision_omero_server_datadir_vgname }}"
@@ -75,7 +75,7 @@
       lvm_shrink: False
 
     # Disk Layout - OMERO.server | LV for dist & logs
-    - role: openmicroscopy.lvm-partition
+    - role: ome.lvm_partition
       tags: lvm
       lvm_lvname: omero_server_basedir
       lvm_vgname: VolGroup00
@@ -85,7 +85,7 @@
       lvm_shrink: False
 
     # Disk Layout - OMERO.web | LV for dist & logs
-    - role: openmicroscopy.lvm-partition
+    - role: ome.lvm_partition
       tags: lvm
       lvm_lvname: omero_web_basedir
       lvm_vgname: VolGroup00

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -102,13 +102,6 @@
     # installation before changing config to restored DB from other system.
     - role: ome.omero_server
       omero_server_release: 5.5.0
-      # Active Directory users not working with role.
-      # Role requires to be manually modified to make it work with an AD user
-      omero_server_system_user: "{{ omero_server_dbuser | default('omero') }}"
-      # Mocking omero_server_datadir for the first run.
-      # Prod value to come from host vars
-      # omero_server_datadir: "/tmp/install-mock_omero-server-datadir"
-      # omero_server_datadir: overridden after inital role run via host vars
       omero_server_datadir_manage: False
       omero_server_systemd_limit_nofile: 16384
       omero_server_systemd_after:

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -65,11 +65,11 @@
   roles:
     # Now OME are using RHEL without Spacewalk, the current best-method of
     # checking `is server SLS` is checking for the SLS nameservers.
-    - role: openmicroscopy.system-monitor-agent
+    - role: ome.system_monitor_agent
       when: "'10.1.255.216' in ansible_dns.nameservers"
 
     # Disk Layout - PostgreSQL | data dir
-    - role: openmicroscopy.lvm-partition
+    - role: ome.lvm_partition
       tags: lvm
       lvm_lvname: pgdata
       lvm_vgname: postgresql
@@ -78,7 +78,7 @@
       lvm_lvfilesystem: "{{ filesystem }}"
 
     # Disk Layout - OMERO | data dir
-    - role: openmicroscopy.lvm-partition
+    - role: ome.lvm_partition
       tags: lvm
       lvm_lvname: basedir
       lvm_vgname: omero
@@ -88,7 +88,7 @@
 
     #  Mock database user & creds, to allow Playbook to install
     #  OMERO, and allow for a manual PostgresSQL dump/restore.
-    - role: openmicroscopy.postgresql
+    - role: ome.postgresql
       postgresql_users_databases:
       - user: install-mock
         password: install-mock

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -89,25 +89,22 @@
     #  Mock database user & creds, to allow Playbook to install
     #  OMERO, and allow for a manual PostgresSQL dump/restore.
     - role: ome.postgresql
-      postgresql_users_databases:
-      - user: install-mock
-        password: install-mock
-        databases: [install-mock]
+      postgresql_databases:
+        - name: "{{ omero_server_dbname | default('omero') }}"
+      postgresql_users:
+      - user: "{{ omero_server_dbuser | default('omero') }}"
+        password: "{{ omero_server_dbpassword | default('omero') }}"
+        databases:
+          - "{{ omero_server_dbname | default('omero') }}"
+
 
     # Note - had to have these set to `install-mock` to progress role
     # installation before changing config to restored DB from other system.
     - role: ome.omero_server
       omero_server_release: 5.5.0
-      # install-mock set for inital provision, then playbook re-run with correct accounts.
-      #omero_server_dbuser: install-mock
-      #omero_server_dbname:  install-mock
-      #omero_server_dbpassword: install-mock
-      omero_server_dbuser: "{{ vault.omero_server_os_user }}"
-      omero_server_dbname:  "{{ vault.omero_server_dbname }}"
-      omero_server_dbpassword: "{{ vault.omero_server_dbpassword }}"
       # Active Directory users not working with role.
       # Role requires to be manually modified to make it work with an AD user
-      omero_server_system_user: "{{ vault.omero_server_os_user }}"
+      omero_server_system_user: "{{ omero_server_dbuser | default('omero') }}"
       # Mocking omero_server_datadir for the first run.
       # Prod value to come from host vars
       # omero_server_datadir: "/tmp/install-mock_omero-server-datadir"

--- a/omero/omero-firewall.yml
+++ b/omero/omero-firewall.yml
@@ -4,7 +4,7 @@
 
   roles:
 
-  - role: openmicroscopy.iptables-raw
+  - role: ome.iptables_raw
 
   tasks:
 

--- a/omero/omero-monitoring-agents.yml
+++ b/omero/omero-monitoring-agents.yml
@@ -4,9 +4,9 @@
 
   roles:
 
-  - role: openmicroscopy.prometheus-jmx
+  - role: ome.prometheus_jmx
 
-  - role: openmicroscopy.prometheus-postgres
+  - role: ome.prometheus_postgres
     prometheus_postgres_dbname: omero
 
   # For restart handlers
@@ -40,7 +40,7 @@
 
   roles:
 
-  - role: openmicroscopy.prometheus-node
+  - role: ome.prometheus_node
 
   # Autodetect whether selinux is enabled
   - role: ome.selinux_utils

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -43,18 +43,18 @@
         databases: [omero]
       postgresql_version: "9.6"
 
-    - role: openmicroscopy.versioncontrol-utils
+    - role: ome.versioncontrol_utils
 
-    - role: openmicroscopy.nfs-mount
+    - role: ome.nfs_mount
 
     - role: ome.omero_server
 
     - role: ome.omero_web
       # omero_web_config_set:
 
-    - role: openmicroscopy.iptables-raw
+    - role: ome.iptables_raw
 
-    - role: openmicroscopy.docker
+    - role: ome.docker
       docker_additional_options:
         # Manually configure to avoid conflicts between Docker and system rules
         iptables: false

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,7 +1,7 @@
 ---
 
-- name: openmicroscopy.certbot
-  src: https://github.com/openmicroscopy/ansible-role-certbot/archive/0.1.0.tar.gz
+- name: ome.certbot
+  src: https://github.com/ome/ansible-role-certbot/archive/0.1.0.tar.gz
   version: 0.1.0
 
 - src: ome.cli_utils
@@ -10,8 +10,8 @@
 - src: ome.deploy_archive
   version: 0.1.3
 
-- src: openmicroscopy.docker
-  version: 3.0.0
+- src: ome.docker
+  version: 3.0.2
 
 - src: ome.ice
   version: 3.0.0
@@ -19,15 +19,14 @@
 - src: ome.java
   version: 2.0.3
 
-- name: openmicroscopy.iptables-raw
-  src: https://github.com/openmicroscopy/ansible-role-iptables-raw/archive/0.2.0.tar.gz
-  version: 0.2.0
+- name: ome.iptables_raw
+  version: 0.2.1
 
-- src: openmicroscopy.lvm-partition
-  version: 1.1.0
+- src: ome.lvm_partition
+  version: 1.1.1
 
-- name: openmicroscopy.network
-  version: 1.1.2
+- name: ome.network
+  version: 1.1.3
 
 - src: ome.nginx
   version: 1.1.1
@@ -35,8 +34,8 @@
 - src: ome.nginx_proxy
   version: 1.12.0
 
-- src: openmicroscopy.nfs-mount
-  version: 1.0.0
+- src: ome.nfs_mount
+  version: 1.2.1
 
 - src: ome.omego
   version: 0.1.3
@@ -65,33 +64,23 @@
 - src: ome.omero_web_django_prometheus
   version: 0.2.1
 
-- src: openmicroscopy.lvm-partition
-  version: 1.1.0
-
-- src: openmicroscopy.postgresql
-  version: 2.0.0
-
 - src: ome.postgresql
   version: 3.2.0
 
-- src: openmicroscopy.postgresql_backup
-  version: 0.1.0
+- src: ome.postgresql_backup
+  version: 0.1.1
 
-- name: openmicroscopy.prometheus
-  src: openmicroscopy.ansible-role-prometheus
-  version: 0.3.0
+- src: ome.prometheus
+  version: 0.3.1
 
-- name: openmicroscopy.prometheus-jmx
-  src: openmicroscopy.ansible-role-prometheus-jmx
-  version: 0.2.0
+- src: ome.prometheus_jmx
+  version: 0.2.1
 
-- name: openmicroscopy.prometheus-node
-  src: openmicroscopy.ansible-role-prometheus-node
-  version: 0.2.0
+- src: ome.prometheus_node
+  version: 0.2.1
 
-- name: openmicroscopy.prometheus-postgres
-  src: openmicroscopy.ansible-role-prometheus-postgres
-  version: 0.2.0
+- src: ome.prometheus_postgres
+  version: 0.2.1
 
 - name: ome.selinux_utils
   version: 1.0.3
@@ -99,17 +88,17 @@
 - src: ome.ssl_certificate
   version: 0.3.2
 
-- src: openmicroscopy.sudoers
-  version: 1.0.0
-
-- src: openmicroscopy.system-monitor-agent
-  version: 0.1.0
-
-- src: openmicroscopy.upgrade-distpackages
-  version: 1.1.0
-
-- src: openmicroscopy.versioncontrol-utils
+- src: ome.sudoers
   version: 1.0.1
+
+- src: ome.system_monitor_agent
+  version: 0.1.1
+
+- src: ome.upgrade_distpackages
+  version: 1.1.1
+
+- src: ome.versioncontrol_utils
+  version: 1.0.2
 
 - name: idr.idr-jupyter
   src: idr.ansible-role-idr-jupyter

--- a/web-proxy/playbook.yml
+++ b/web-proxy/playbook.yml
@@ -3,15 +3,15 @@
 
 - hosts: web-proxies
   roles:
-  - role: openmicroscopy.network
+  - role: ome.network
     tags: network
-  - role: openmicroscopy.lvm-partition
+  - role: ome.lvm_partition
     tags: lvm
     lvm_lvname: root
     lvm_lvmount: /
     lvm_lvsize: "{{ root_size }}"
     lvm_lvfilesystem: "{{ root_filesystem }}"
-  - role: openmicroscopy.lvm-partition
+  - role: ome.lvm_partition
     tags: lvm
     lvm_lvname: var_log
     lvm_lvmount: /var/log

--- a/www/playbook.yml
+++ b/www/playbook.yml
@@ -55,7 +55,7 @@
   roles:
     # Now OME are using RHEL without Spacewalk, the current best-method of
     # checking `is server deployed in Dundee/SLS` is checking for the SLS nameservers.
-    - role: openmicroscopy.system-monitor-agent
+    - role: ome.system_monitor_agent
       tags: monitoring
       when: "'10.1.255.216' in ansible_dns.nameservers"
 


### PR DESCRIPTION
This should complete the review and the update of this playbook repository to drop the usage of the deprecated Galaxy [openmicroscopy](https://galaxy.ansible.com/openmicroscopy/) roles in favor of the new [ome](https://galaxy.ansible.com/ome/) ones.

The changes in `requirements.yml` should mainly consist of patch version increments of the Galaxy roles as per the migration. Two exceptions:

- `ome.nfs_mount`: `1.0.0` -> `1.2.1` (Ubuntu support, passno parameter, nfs version support, CI & molecule2)
- `openmicroscopy.postgresql 2.0.0` is fully superseded by `ome.postgresql`
- the `ome-dundeeomero` playbook is upgraded to consume `ome.postgresql`