### PR TITLE
Upgrade apps and training-scripts versions

### DIFF
--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -298,15 +298,15 @@
     omero_web_release: "{{ omero_web_release_override | default('5.5.1') }}"
     omero_figure_release: "{{ omero_figure_release_override | default('4.0.2') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.3.0') }}"
-    omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.8.0') }}"
-    omero_mapr_release: "{{ omero_mapr_release_override | default('0.2.3') }}"
+    omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.8.1') }}"
+    omero_mapr_release: "{{ omero_mapr_release_override | default('0.3.2') }}"
     omero_parade_release: "{{ omero_parade_release_override | default('0.1.3') }}"
-    ome_training_scripts_release: "{{ ome_training_scripts_release_override | default('0.6.0') }}"
+    ome_training_scripts_release: "{{ ome_training_scripts_release_override | default('0.6.1') }}"
     omero_webtagging_autotag_release: "{{ omero_webtagging_autotag_release_override | default('3.0.2') }}"
     omero_webtagging_tagsearch_release: "{{ omero_webtagging_tagsearch_release_override | default('3.0.3') }}"
     omero_cli_duplicate_release: "{{ omero_cli_duplicate_release_override | default('0.2.0') }}"
-    omero_metadata_release: "{{ omero_metadata_release_overrride | default('0.4.0') }}"
-    omero_cli_render_release: "{{ omero_cli_render_release_override | default('0.4.2') }}"
+    omero_metadata_release: "{{ omero_metadata_release_overrride | default('0.4.1') }}"
+    omero_cli_render_release: "{{ omero_cli_render_release_override | default('0.4.3') }}"
     # The os_system_users_password default is "ome".
     # You may wish to change this variable,
     # or override it by defining the private variable os_system_users_password_override.


### PR DESCRIPTION
This is in preparation of the Munich workshop (next week)

Upgrading among others iviewer and training-scripts (new release to fix "simple frap" script there).

The changes are pertaining only to ``outreach`` server. The ``workshop`` server is its mirror, nevertheless, after consultation with @manics I was told that a tactics where both servers will be governed by a single playbook is being worked on. 
But, in the meantime, to avoid some conflicts, I am expected to prep the playbook changes as I did up till now (and for ``outreach`` only).

cc @manics @sbesson @jburel @dominikl 

The playbook was successfully run against ``outreach`` and all is fine.