### PR TITLE
Update public image folders to consume new public OME-TIFF/OME-XML folders

### DIFF
--- a/release/group_vars/all.yml
+++ b/release/group_vars/all.yml
@@ -34,6 +34,8 @@ public_folders:
   nifti: 'NIfTI'
   nrrd: 'NRRD'
   olympus-oir: 'Olympus-OIR'
+  ome-xml: 'OME-XML'
+  ome-tiff: 'OME-TIFF'
   perkinelmer-operetta: 'PerkinElmer-Operetta'
   png: 'PNG'
   svs: 'SVS'
@@ -52,6 +54,4 @@ special_public_folders:
   - { src: '../../../../repos/curated/cellomics/public/', dest: 'HCS/BBBC'}
   - { src: '../../../../repos/curated/incell/public/', dest: 'HCS/INCELL2000'}
   - { src: '../../../../repos/curated/perkinelmer-operetta/public/', dest: 'HCS/Operetta'}
-  - { src: '../../../repos/curated/ome-tiff/ome-schemas/', dest: 'OME-TIFF'}
-  - { src: '../../../repos/curated/ome-xml/ome-schemas/', dest: 'OME-XML'}
   - { src: '../../../repos/curated/zip/u-track/', dest: 'u-track'}


### PR DESCRIPTION
As discussed with @ome/formats, the internal name of the public folders has been changed to `public` to match the other formats.

This playbook has been deployed so that https://downloads.openmicroscopy.org/images/OME-TIFF/ and https://downloads.openmicroscopy.org/images/OME-XML/ keep working.

Proposing to merge as soon once Travis is green.