### PR TITLE
fix outstanding playbook issues

### DIFF
--- a/learning.yml
+++ b/learning.yml
@@ -69,16 +69,9 @@
         omero.security.trustStorePassword: "changeit"
         omero.sessions.timeout: 3600000
 
-    - role: mtbc.java_certificate
-      java_certificate_url: "{{ ldap_host }}"
-      java_certificate_port: 636
-
     - role: ome.redis
 
     - role: ome.nginx
-
-    - role: mtbc.nginx_configure
-      nginx_configure_omero_web_conf_source: "omero/files/learning-omero-web.conf"
 
     - role: ome.omero_web
       ice_python_wheel: https://github.com/ome/zeroc-ice-py-centos7/releases/download/0.1.0/zeroc_ice-3.6.4-cp27-cp27mu-linux_x86_64.whl
@@ -122,3 +115,21 @@
         - omero-gallery
         - omero-iviewer
         - omero-virtual-microscope
+
+  tasks:
+    - name: TLS certificate is installed for JVM
+      become: yes
+      java_cert:
+        cert_url: "{{ ldap_host }}"
+        cert_port: 636
+        keystore_path: "/etc/pki/java/cacerts"
+        keystore_pass: changeit
+        state: present
+      notify: restart omero-server
+
+    - name: OMERO.web configuration is installed
+      become: yes
+      copy:
+        src: "omero/files/learning-omero-web.conf"
+        dest: "/etc/nginx/conf.d/omero-web.conf"
+      notify: restart nginx

--- a/requirements.yml
+++ b/requirements.yml
@@ -109,9 +109,3 @@
 - name: idr.idr-jupyter
   src: idr.ansible-role-idr-jupyter
   version: 3.0.0
-
-- name: mtbc.java_certificate
-  version: 0.1.0
-
-- name: mtbc.nginx_configure
-  version: 0.1.1

--- a/sls-gallery.yml
+++ b/sls-gallery.yml
@@ -67,16 +67,9 @@
         omero.security.keyStorePassword: "changeit"
         omero.security.trustStorePassword: "changeit"
 
-    - role: mtbc.java_certificate
-      java_certificate_url: "{{ ldap_host }}"
-      java_certificate_port: 636
-
     - role: ome.redis
 
     - role: ome.nginx
-
-    - role: mtbc.nginx_configure
-      nginx_configure_omero_web_conf_source: "omero/files/sls-gallery-omero-web.conf"
 
     - role: ome.omero_web
       ice_python_wheel: https://github.com/ome/zeroc-ice-py-centos7/releases/download/0.1.0/zeroc_ice-3.6.4-cp27-cp27mu-linux_x86_64.whl
@@ -114,3 +107,21 @@
     - role: ome.omero_web_apps
       omero_web_apps_packages:
         - omero-iviewer
+
+  tasks:
+    - name: TLS certificate is installed for JVM
+      become: yes
+      java_cert:
+        cert_url: "{{ ldap_host }}"
+        cert_port: 636
+        keystore_path: "/etc/pki/java/cacerts"
+        keystore_pass: changeit
+        state: present
+      notify: restart omero-server
+
+    - name: OMERO.web configuration is installed
+      become: yes
+      copy:
+        src: "omero/files/sls-gallery-omero-web.conf"
+        dest: "/etc/nginx/conf.d/omero-web.conf"
+      notify: restart nginx


### PR DESCRIPTION
For both Virtual Microscope and SLS Gallery,
- Removes use of `mtbc.*` roles. (https://github.com/openmicroscopy/management_tools/pull/1113 covers the remaining TLS certificate configuration.)

Fixes #216. Other improvements will follow in subsequent PRs once this is merged.