### PR TITLE
Force upgrade of OMERO.iviewer on Virtual Microscope.

### DIFF
--- a/learning.yml
+++ b/learning.yml
@@ -113,7 +113,7 @@
     - role: ome.omero_web_apps
       omero_web_apps_packages:
         - omero-gallery
-        - omero-iviewer>=0.8
+        - omero-iviewer==0.8.1
         - omero-virtual-microscope
 
   tasks:

--- a/learning.yml
+++ b/learning.yml
@@ -112,9 +112,9 @@
 
     - role: ome.omero_web_apps
       omero_web_apps_packages:
-        - omero-gallery
+        - omero-gallery==3.1.1
         - omero-iviewer==0.8.1
-        - omero-virtual-microscope
+        - omero-virtual-microscope==1.0.1
 
   tasks:
     - name: TLS certificate is installed for JVM

--- a/learning.yml
+++ b/learning.yml
@@ -40,7 +40,7 @@
     - role: ome.omero_server
       ice_python_wheel: https://github.com/ome/zeroc-ice-py-centos7/releases/download/0.1.0/zeroc_ice-3.6.4-cp27-cp27mu-linux_x86_64.whl
       omero_server_systemd_start: False
-      omero_server_release: latest
+      omero_server_release: 5.5.1
       omero_server_dbpassword: "{{ database_password }}"
       omero_server_rootpassword: "{{ server_password }}"
       omero_server_config_set:
@@ -77,7 +77,7 @@
       ice_python_wheel: https://github.com/ome/zeroc-ice-py-centos7/releases/download/0.1.0/zeroc_ice-3.6.4-cp27-cp27mu-linux_x86_64.whl
       omero_web_setup_nginx: False
       omero_web_systemd_start: False
-      omero_web_release: latest
+      omero_web_release: 5.5.1
       omero_web_config_set:
         omero.web.server_list:
           - ["localhost", 4064, "Virtual Microscope"]

--- a/learning.yml
+++ b/learning.yml
@@ -113,7 +113,7 @@
     - role: ome.omero_web_apps
       omero_web_apps_packages:
         - omero-gallery
-        - omero-iviewer
+        - omero-iviewer>=0.8
         - omero-virtual-microscope
 
   tasks:


### PR DESCRIPTION
OMERO.iviewer on https://learning.openmicroscopy.org/ is still back on v0.7.1. This PR ensures that when the playbook is run for the next scheduled maintenance of Virtual Microscope OMERO.iviewer will be upgraded to the latest stable version.