### PR TITLE
start services on boot: learning, sls-repo

### DIFF
--- a/learning.yml
+++ b/learning.yml
@@ -133,3 +133,13 @@
         src: "omero/files/learning-omero-web.conf"
         dest: "/etc/nginx/conf.d/omero-web.conf"
       notify: restart nginx
+
+    - name: services are started on boot
+      become: yes
+      service:
+        name: "{{ item }}.service"
+        enabled: true
+      loop:
+        - nginx
+        - omero-server
+        - omero-web

--- a/learning.yml
+++ b/learning.yml
@@ -39,7 +39,6 @@
 
     - role: ome.omero_server
       ice_python_wheel: https://github.com/ome/zeroc-ice-py-centos7/releases/download/0.1.0/zeroc_ice-3.6.4-cp27-cp27mu-linux_x86_64.whl
-      omero_server_systemd_start: False
       omero_server_release: latest
       omero_server_dbpassword: "{{ database_password }}"
       omero_server_rootpassword: "{{ server_password }}"
@@ -134,12 +133,11 @@
         dest: "/etc/nginx/conf.d/omero-web.conf"
       notify: restart nginx
 
-    - name: services are started on boot
+    - name: OMERO.web starts on boot
       become: yes
       service:
         name: "{{ item }}.service"
         enabled: true
       loop:
         - nginx
-        - omero-server
         - omero-web

--- a/sls-gallery.yml
+++ b/sls-gallery.yml
@@ -125,3 +125,13 @@
         src: "omero/files/sls-gallery-omero-web.conf"
         dest: "/etc/nginx/conf.d/omero-web.conf"
       notify: restart nginx
+
+    - name: services are started on boot
+      become: yes
+      service:
+        name: "{{ item }}.service"
+        enabled: true
+      loop:
+        - nginx
+        - omero-server
+        - omero-web

--- a/sls-gallery.yml
+++ b/sls-gallery.yml
@@ -37,7 +37,6 @@
 
     - role: ome.omero_server
       ice_python_wheel: https://github.com/ome/zeroc-ice-py-centos7/releases/download/0.1.0/zeroc_ice-3.6.4-cp27-cp27mu-linux_x86_64.whl
-      omero_server_systemd_start: False
       omero_server_release: latest
       omero_server_dbpassword: "{{ database_password }}"
       omero_server_rootpassword: "{{ server_password }}"
@@ -126,12 +125,11 @@
         dest: "/etc/nginx/conf.d/omero-web.conf"
       notify: restart nginx
 
-    - name: services are started on boot
+    - name: OMERO.web starts on boot
       become: yes
       service:
         name: "{{ item }}.service"
         enabled: true
       loop:
         - nginx
-        - omero-server
         - omero-web


### PR DESCRIPTION
Both `learning.yml` and `sls-gallery.yml` include,
```
omero_server_systemd_start: False
omero_web_systemd_start: False
omero_web_setup_nginx: False
```
It wasn't clear to me that this also prevents the services from being enabled at all. This extra task fixes that issue. The services are already otherwise enabled on the actual server but this PR reflects that.