### PR TITLE
separate /opt/omero/ mount on learning and sls-repo

### DIFF
--- a/learning.yml
+++ b/learning.yml
@@ -37,6 +37,14 @@
       lvm_lvfilesystem: xfs
       lvm_shrink: False
 
+    - role: ome.lvm_partition
+      lvm_vgname: VolGroup00
+      lvm_lvname: 'opt_omero'
+      lvm_lvmount: '/opt/omero'
+      lvm_lvsize: 40G
+      lvm_lvfilesystem: xfs
+      lvm_shrink: False
+
     - role: ome.omero_server
       ice_python_wheel: https://github.com/ome/zeroc-ice-py-centos7/releases/download/0.1.0/zeroc_ice-3.6.4-cp27-cp27mu-linux_x86_64.whl
       omero_server_systemd_start: False

--- a/sls-gallery.yml
+++ b/sls-gallery.yml
@@ -35,6 +35,14 @@
       lvm_lvfilesystem: xfs
       lvm_shrink: False
 
+    - role: ome.lvm_partition
+      lvm_vgname: VolGroup00
+      lvm_lvname: 'opt_omero'
+      lvm_lvmount: '/opt/omero'
+      lvm_lvsize: 40G
+      lvm_lvfilesystem: xfs
+      lvm_shrink: False
+
     - role: ome.omero_server
       ice_python_wheel: https://github.com/ome/zeroc-ice-py-centos7/releases/download/0.1.0/zeroc_ice-3.6.4-cp27-cp27mu-linux_x86_64.whl
       omero_server_systemd_start: False


### PR DESCRIPTION
Adds space for OMERO.server and OMERO.web to live separately on `/opt/omero/`. Should already pass for SLS Gallery but will fail on Virtual Microscope until existing data is migrated during the maintenance window.