### PR TITLE
Compress OMERO.server logs for learning and sls-repo.

### DIFF
--- a/learning.yml
+++ b/learning.yml
@@ -124,6 +124,22 @@
         - omero-virtual-microscope==1.0.1
 
   tasks:
+    - name: find OMERO.server log configuration
+      become: yes
+      find:
+        paths: /opt/omero/server/OMERO.server/etc/
+        patterns: "logback*.xml"
+      register: logbacks
+
+    - name: OMERO.server logs are compressed on rollover
+      become: yes
+      replace:
+        path: "{{ item.path }}"
+        regexp: "(\\<fileNamePattern\\>\\$\\{omero\\.logfile\\}\\.\\%i)(\\<\\/fileNamePattern\\>)"
+        replace: "\\1.gz\\2"
+        backup: yes
+      with_items: "{{ logbacks.files }}"
+
     - name: TLS certificate is installed for JVM
       become: yes
       java_cert:

--- a/sls-gallery.yml
+++ b/sls-gallery.yml
@@ -116,6 +116,22 @@
         - omero-iviewer
 
   tasks:
+    - name: find OMERO.server log configuration
+      become: yes
+      find:
+        paths: /opt/omero/server/OMERO.server/etc/
+        patterns: "logback*.xml"
+      register: logbacks
+
+    - name: OMERO.server logs are compressed on rollover
+      become: yes
+      replace:
+        path: "{{ item.path }}"
+        regexp: "(\\<fileNamePattern\\>\\$\\{omero\\.logfile\\}\\.\\%i)(\\<\\/fileNamePattern\\>)"
+        replace: "\\1.gz\\2"
+        backup: yes
+      with_items: "{{ logbacks.files }}"
+
     - name: TLS certificate is installed for JVM
       become: yes
       java_cert:


### PR DESCRIPTION
The Virtual Microscope and SLS Gallery servers have finite space for `/opt/omero/` and OMERO.server logs are so large and compressible that it seems well worth saving that space so this PR adjusts the Logback configuration to compress log files on rollover.

This has already been run on SLS Gallery. For Virtual Microscope we'll wait for the next maintenance window such as when 5.6.1 is released.

At a quieter time we should look at where we can roll the functionality of these various tasks into existing or new roles.