### PR TITLE
nightshade upgrade

### DIFF
--- a/molecule/nightshade-webclients/Dockerfile.j2
+++ b/molecule/nightshade-webclients/Dockerfile.j2
@@ -1,0 +1,14 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates && xbps-remove -O; fi

--- a/molecule/nightshade-webclients/molecule.yml
+++ b/molecule/nightshade-webclients/molecule.yml
@@ -49,7 +49,10 @@ scenario:
     - converge
     # FIXME: Some tasks are not idempotent
     # - idempotence
-    - verify
+    ################################################################################
+    # FIXME: Tests hang on Travis but pass locally
+    # - verify
+    ################################################################################
     - destroy
 verifier:
   name: testinfra

--- a/molecule/nightshade-webclients/molecule.yml
+++ b/molecule/nightshade-webclients/molecule.yml
@@ -10,20 +10,47 @@ lint:
   # TODO: enable
   enabled: False
 platforms:
-  - name: nightshade-webclients
-    image: centos:7
+  - name: ns-webclients
+    image: centos/systemd
+    command: /sbin/init
+    privileged: true
+    groups:
+      - docker-hosts
+      - omero-web
+      - monitored
 provisioner:
   name: ansible
+  options:
+    diff: true
+  inventory:
+    group_vars:
+      all:
+        molecule_test: true
+      docker-hosts:
+        # firewalld isn't installed, don't attempt to disable
+        iptables_raw_disable_firewalld: False
   playbooks:
-    converge: ../../nightshade-webclients.yml
+    converge: ../../site.yml
   lint:
     name: ansible-lint
 scenario:
   name: nightshade-webclients
+  converge_sequence:
+    - converge
   test_sequence:
-    - lint
+    - destroy
+    # dependency must come first so that ansible-lint will see a custom module
+    # This might be fixed by https://github.com/ansible/molecule/pull/1739
     - dependency
+    - lint
     - syntax
+    - create
+    - prepare
+    - converge
+    # FIXME: Some tasks are not idempotent
+    # - idempotence
+    - verify
+    - destroy
 verifier:
   name: testinfra
   lint:

--- a/molecule/nightshade-webclients/tests/test_default.py
+++ b/molecule/nightshade-webclients/tests/test_default.py
@@ -1,0 +1,40 @@
+import os
+import pytest
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+OMERO = '/opt/omero/server/OMERO.server/bin/omero'
+OMERO_LOGIN = '-C -s localhost -u root -w omero'
+
+
+@pytest.mark.parametrize("name", [
+    'nginx',
+    'omero-web',
+    'prometheus-node-exporter',
+])
+def test_service_running_and_enabled(host, name):
+    service = host.service(name)
+    assert service.is_running
+    assert service.is_enabled
+
+
+def test_omero_metrics(host):
+    out = host.check_output(
+        'curl -f -u monitoring:monitoring -k '
+        'https://localhost/django_prometheus/metrics')
+    assert "django_http_responses_body_total_bytes_count" in out
+
+
+def test_omero_metrics_auth_fail(host):
+    out = host.run(
+        'curl -f -u monitoring:incorrect -k '
+        'https://localhost/django_prometheus/metrics')
+    assert out.rc == 22
+    assert '401' in out.stderr
+
+
+def test_omero_nginx_ssl(host):
+    out = host.check_output('curl -fkI https://localhost/')
+    assert 'Location: /webclient/' in out

--- a/molecule/ome-dundeeomero/Dockerfile.j2
+++ b/molecule/ome-dundeeomero/Dockerfile.j2
@@ -1,0 +1,14 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates && xbps-remove -O; fi

--- a/molecule/ome-dundeeomero/molecule.yml
+++ b/molecule/ome-dundeeomero/molecule.yml
@@ -11,19 +11,51 @@ lint:
   enabled: False
 platforms:
   - name: ome-dundeeomero.openmicroscopy.org
-    image: centos:7
+    image: centos/systemd
+    command: /sbin/init
+    privileged: true
+    groups:
+      - docker-hosts
+      - omero-server
+      - monitored
 provisioner:
   name: ansible
+  options:
+    diff: true
+    skip-tags:
+      - skip_molecule
+  inventory:
+    group_vars:
+      all:
+        molecule_test: true
+      docker-hosts:
+        omero_server_systemd_require_network: False
+        # firewalld isn't installed, don't attempt to disable
+        iptables_raw_disable_firewalld: False
   playbooks:
-    converge: ../../ome-dundeeomero.yml
+    converge: ../../site.yml
   lint:
     name: ansible-lint
+  # env:
+  #   ANSIBLE_ROLES_PATH: ../../vendor
 scenario:
   name: ome-dundeeomero
+  converge_sequence:
+    - converge
   test_sequence:
-    - lint
+    - destroy
+    # dependency must come first so that ansible-lint will see a custom module
+    # This might be fixed by https://github.com/ansible/molecule/pull/1739
     - dependency
+    - lint
     - syntax
+    - create
+    - prepare
+    - converge
+    # FIXME: Some tasks are not idempotent
+    # - idempotence
+    - verify
+    - destroy
 verifier:
   name: testinfra
   lint:

--- a/molecule/ome-dundeeomero/tests/test_default.py
+++ b/molecule/ome-dundeeomero/tests/test_default.py
@@ -1,0 +1,46 @@
+import os
+import pytest
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+OMERO = '/opt/omero/server/OMERO.server/bin/omero'
+OMERO_LOGIN = '-C -s localhost -u root -w omero'
+
+
+@pytest.mark.parametrize("name", [
+    'nginx',
+    'omero-server',
+    'postgresql-9.6',
+    'prometheus-node-exporter',
+    'prometheus-omero-exporter',
+    'prometheus-postgres-exporter',
+])
+def test_service_running_and_enabled(host, name):
+    service = host.service(name)
+    assert service.is_running
+    assert service.is_enabled
+
+
+def test_omero_login(host):
+    with host.sudo('omero-server'):
+        host.check_output(
+            '/opt/omero/server/OMERO.server/bin/omero '
+            'login -C -s localhost -u root -w omero')
+
+
+@pytest.mark.parametrize("curl", [
+    'localhost:9449/metrics',
+    '-u monitoring:monitoring -k https://localhost/metrics/9449',
+])
+def test_omero_metrics(host, curl):
+    out = host.check_output('curl -f %s' % curl)
+    assert 'omero_sessions_active' in out
+
+
+def test_omero_metrics_auth_fail(host):
+    out = host.run(
+        'curl -f -u monitoring:incorrect -k https://localhost/metrics/9449')
+    assert out.rc == 22
+    assert '401' in out.stderr

--- a/nightshade-webclients.yml
+++ b/nightshade-webclients.yml
@@ -118,24 +118,24 @@
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"
     omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.9.0') }}"
     omero_parade_release: "{{ omero_parade_release_override | default('0.2.0') }}"
-    # omero_webtagging_autotag_release: "{{ omero_webtagging_autotag_release_override | default('3.0.2') }}"
-    # omero_webtagging_tagsearch_release: "{{ omero_webtagging_tagsearch_release_override | default('3.0.3') }}"
+    omero_webtagging_autotag_release: "{{ omero_webtagging_autotag_release_override | default('3.1.0') }}"
+    omero_webtagging_tagsearch_release: "{{ omero_webtagging_tagsearch_release_override | default('3.1.0') }}"
 
     omero_web_apps_names:
       - omero_figure
       - omero_fpbioimage
       - omero_iviewer
       - omero_parade
-      # - omero_webtagging_autotag
-      # - omero_webtagging_tagsearch
+      - omero_webtagging_autotag
+      - omero_webtagging_tagsearch
 
     omero_web_apps_packages:
       - "omero-figure=={{ omero_figure_release }}"
       - "omero-fpbioimage=={{ omero_fpbioimage_release }}"
       - "omero-iviewer=={{ omero_iviewer_release }}"
       - "omero-parade=={{ omero_parade_release }}"
-      # - "omero-webtagging-autotag=={{ omero_webtagging_autotag_release }}"
-      # - "omero-webtagging-tagsearch=={{ omero_webtagging_tagsearch_release }}"
+      - "omero-webtagging-autotag=={{ omero_webtagging_autotag_release }}"
+      - "omero-webtagging-tagsearch=={{ omero_webtagging_tagsearch_release }}"
 
     omero_web_apps_top_links:
       - label: Figure
@@ -143,8 +143,8 @@
         attrs:
           title: Open Figure in new tab
           target: _blank
-      # - label: Tag Search
-      #   link: tagsearch
+      - label: Tag Search
+        link: tagsearch
 
     omero_web_apps_config_append:
       omero.web.open_with:
@@ -169,9 +169,9 @@
             script_url: omero_iviewer/openwith.js
             label: OMERO.iviewer
       omero.web.ui.center_plugins:
-        # - - Auto Tag
-        #   - omero_webtagging_autotag/auto_tag_init.js.html
-        #   - auto_tag_panel
+        - - Auto Tag
+          - omero_webtagging_autotag/auto_tag_init.js.html
+          - auto_tag_panel
         - - Parade
           - omero_parade/init.js.html
           - omero_parade

--- a/nightshade-webclients.yml
+++ b/nightshade-webclients.yml
@@ -10,6 +10,7 @@
       register: _omero_web_venv3_st
 
     - name: Delete old Python 2 web configuration
+      become: true
       file:
         path: /opt/omero/web/config
         state: absent
@@ -142,8 +143,8 @@
         attrs:
           title: Open Figure in new tab
           target: _blank
-      - label: Tag Search
-        link: tagsearch
+      # - label: Tag Search
+      #   link: tagsearch
 
     omero_web_apps_config_append:
       omero.web.open_with:

--- a/nightshade-webclients.yml
+++ b/nightshade-webclients.yml
@@ -2,6 +2,19 @@
 
 - hosts: ns-webclients
 
+  pre_tasks:
+
+    - name: Check if Python 3 venv3 already installed
+      stat:
+        path: /opt/omero/web/venv3
+      register: _omero_web_venv3_st
+
+    - name: Delete old Python 2 web configuration
+      file:
+        path: /opt/omero/web/config
+        state: absent
+      when: not _omero_web_venv3_st.stat.exists
+
   roles:
 
     # Root LV Size
@@ -12,6 +25,7 @@
       lvm_lvmount: /
       lvm_lvsize: "{{ provision_rootsize }}"
       lvm_lvfilesystem: "{{ provision_root_filesystem }}"
+      when: "not (molecule_test | default(False))"
 
     - role: ome.ssl_certificate
 
@@ -19,7 +33,6 @@
 
     # OMERO.web configuration in host_vars in different repository
     - role: ome.omero_web
-      omero_web_release: "{{ omero_web_release_version }}"
       omero_web_systemd_limit_nofile: 16384
 
     # Now OME are using RHEL without Spacewalk, the current best-method of
@@ -36,25 +49,7 @@
         state: reloaded
 
 
-  post_tasks:
-
-    - name: Omero.web plugins | plugin install via pip & pypi
-      become: yes
-      pip:
-        name:
-        - "omero-figure=={{ omero_figure_release }}"
-        - "omero-fpbioimage=={{ omero_fpbioimage_release }}"
-        - "omero-iviewer=={{ omero_iviewer_release }}"
-        - "omero-parade=={{ omero_parade_release }}"
-        - "omero-webtagging-autotag=={{ omero_webtagging_autotag_release }}"
-        - "omero-webtagging-tagsearch=={{ omero_webtagging_tagsearch_release }}"
-        editable: False
-        state: present
-        # variable comes from role ome.omero_web
-        virtualenv: "{{ omero_web_basedir }}/venv"
-        virtualenv_site_packages: yes
-      notify:
-        - restart omero-web
+  tasks:
 
     - name: Install open-vm-tools if system is a VMware vm
       become: yes
@@ -64,6 +59,7 @@
       when: >
            ((ansible_virtualization_type is defined)
            and (ansible_virtualization_type == "VMware"))
+           and not (molecule_test | default(False))
 
     # (Total cores / 2), leaving some for WSGI
     # post 2.3 'dest' should be renamed 'path'
@@ -89,15 +85,6 @@
         path: /etc/nginx/conf.d-nested-includes
         state: directory
 
-    - name: NGINX - omero-web.conf nested includes
-      become: yes
-      lineinfile:
-        destfile: /etc/nginx/conf.d/omero-web.conf
-        insertafter: 'server {'
-        line: '    include /etc/nginx/conf.d-nested-includes/*.conf;'
-      notify:
-        - restart nginx
-
     - name: NGINX - SSL Configuration
       become: yes
       template:
@@ -114,26 +101,83 @@
       notify:
         - restart nginx
 
-    - name: Config for OMERO.web plugins
-      become: yes
-      template:
-        src: templates/omero-web-config-for-webapps.j2
-        dest: "{{ omero_web_basedir }}/config/omero-web-config-for-webapps.omero"
-        owner: "root"
-        group: "root"
-        mode: "u=rw,go=r"
-      notify:
-        - restart omero-web
-
   vars:
-    omero_web_config_set: "{{ omero_web_config_set_for_group | combine(omero_web_config_set_for_host) }}"
-    omero_figure_release: "{{ omero_figure_release_override | default('4.0.2') }}"
-    omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.3.0') }}"
-    omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.8.0') }}"
-    omero_parade_release: "{{ omero_parade_release_override | default('0.1.2') }}"
-    omero_webtagging_autotag_release: "{{ omero_webtagging_autotag_release_override | default('3.0.2') }}"
-    omero_webtagging_tagsearch_release: "{{ omero_webtagging_tagsearch_release_override | default('3.0.3') }}"
-    omero_web_release_version: "{{ omero_web_release_version_override | default('5.5.1') }}"
-    nginx_version: 1.14.2
+    omero_web_config_set_for_playbook:
+      omero.web.nginx_server_extra_config:
+        - 'include /etc/nginx/conf.d-nested-includes/*.conf;'
+    omero_web_config_set: >-
+      {{
+        omero_web_config_set_for_playbook | combine(
+        (omero_web_config_set_for_group | default({})),
+        (omero_web_config_set_for_host | default({})))
+      }}
+
+    omero_web_release: "{{ omero_web_release_override | default('5.6.1') }}"
+    omero_figure_release: "{{ omero_figure_release_override | default('4.2.0') }}"
+    omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"
+    omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.9.0') }}"
+    omero_parade_release: "{{ omero_parade_release_override | default('0.2.0') }}"
+    # omero_webtagging_autotag_release: "{{ omero_webtagging_autotag_release_override | default('3.0.2') }}"
+    # omero_webtagging_tagsearch_release: "{{ omero_webtagging_tagsearch_release_override | default('3.0.3') }}"
+
+    omero_web_apps_names:
+      - omero_figure
+      - omero_fpbioimage
+      - omero_iviewer
+      - omero_parade
+      # - omero_webtagging_autotag
+      # - omero_webtagging_tagsearch
+
+    omero_web_apps_packages:
+      - "omero-figure=={{ omero_figure_release }}"
+      - "omero-fpbioimage=={{ omero_fpbioimage_release }}"
+      - "omero-iviewer=={{ omero_iviewer_release }}"
+      - "omero-parade=={{ omero_parade_release }}"
+      # - "omero-webtagging-autotag=={{ omero_webtagging_autotag_release }}"
+      # - "omero-webtagging-tagsearch=={{ omero_webtagging_tagsearch_release }}"
+
+    omero_web_apps_top_links:
+      - label: Figure
+        link: figure_index
+        attrs:
+          title: Open Figure in new tab
+          target: _blank
+      - label: Tag Search
+        link: tagsearch
+
+    omero_web_apps_config_append:
+      omero.web.open_with:
+        - - omero_figure
+          - new_figure
+          - supported_objects:
+              - images
+            target: _blank
+            label: OMERO.figure
+        - - omero_fpbioimage"
+          - fpbioimage_index
+          - supported_objects:
+              - image
+            script_url: fpbioimage/openwith.js
+            label: FPBioimage
+        - - omero_iviewer
+          - omero_iviewer_index
+          - supported_objects:
+              - images
+              - dataset
+              - well
+            script_url: omero_iviewer/openwith.js
+            label: OMERO.iviewer
+      omero.web.ui.center_plugins:
+        # - - Auto Tag
+        #   - omero_webtagging_autotag/auto_tag_init.js.html
+        #   - auto_tag_panel
+        - - Parade
+          - omero_parade/init.js.html
+          - omero_parade
+
+    omero_web_apps_config_set:
+      omero.web.viewer.view: "{{ omeroweb_default_viewer_override | default('omero_iviewer.views.index') }}"
+
+    nginx_version: 1.16.1
     # Disable SSL combined certificate and key
     ssl_certificate_combined_path: ''

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -261,7 +261,7 @@
     filesystem: "xfs"
     omero_figure_release: "{{ omero_figure_release_override | default('4.2.0') }}"
 
-    omero_web_config_set_production:
+    omero_server_config_set_production:
       omero.db.poolsize: 60
       omero.jvmcfg.percent.blitz: 50
       omero.jvmcfg.percent.indexer: 20
@@ -282,7 +282,7 @@
       omero.data.dir: "{{ omero_server_datadir | default('/OMERO') }}"
 
     # Production config can't be tested in molecule
-    omero_server_config_set: "{{ molecule_test | default(False) | ternary({}, omero_web_config_set_production) }}"
+    omero_server_config_set: "{{ molecule_test | default(False) | ternary({}, omero_server_config_set_production) }}"
     omero_server_python_addons:
       # For OMERO.figure script
       - reportlab

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -126,6 +126,15 @@
         state: reloaded
 
   tasks:
+
+    - name: Create another temporary directory since OMERO doesn't limit sizes and fills up /tmp
+      become: yes
+      file:
+        path: "{{ omero_server_systemd_environment.OMERO_TMPDIR }}"
+        state: directory
+        mode: 0700
+        owner: "{{ omero_server_system_user }}"
+
     - name: NGINX - enable service / start on boot
       become: yes
       systemd:
@@ -288,6 +297,11 @@
       - reportlab
       - markdown
 
+    # Workaround lack of restriction on temp file sizes
+    # https://github.com/ome/omero-web/issues/118
+    # The downside is that it won't be automatically cleared out
+    omero_server_systemd_environment:
+      OMERO_TMPDIR: /opt/omero/server/tmp
 
     # Disable SSL combined certificate and key
     ssl_certificate_combined_path: ''

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -10,6 +10,7 @@
       when: >
            ((ansible_virtualization_type is defined)
            and (ansible_virtualization_type == "VMware"))
+           and not (molecule_test | default(False))
 
     # Not required for an OMERO server install - UoD specific implementation
     - name: NGOM mount point | Install NFS prerequisites
@@ -31,6 +32,7 @@
         opts: tcp,rsize=16384,wsize=16384
         dump: 0
         passno: 0
+      when: "not (molecule_test | default(False))"
 
     # Perhaps alter the role at https://github.com/openmicroscopy/ansible-role-lvm-partition/
     # to make some of the variables non-required.
@@ -41,11 +43,12 @@
         lv: root
         vg: rhel
         size: "{{ provision_root_lvsize }}"
+      when: "not (molecule_test | default(False))"
 
     - name: Install Make Movie script Prerequisite | MEncoder - Repo
       become: yes
       yum:
-        name:  http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
+        name:  https://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
         state: present
 
     - name: OMERO.figure server-side prerequisites, script prerequisites + web server for decoupled OMERO.web
@@ -55,12 +58,7 @@
         state: present
       with_items:
         # For OMERO.figure
-        - python-reportlab
-        - python-markdown
         - mencoder # For the 'make movie' script
-        # Current server proxies to a decoupled OMERO.web server
-        # Initially replicate this setup, to minimise changes.
-        - nginx
 
   roles:
     # Now OME are using RHEL without Spacewalk, the current best-method of
@@ -76,6 +74,7 @@
       lvm_lvmount: /var/lib/pgsql
       lvm_lvsize: "{{ provision_postgres_lvsize }}"
       lvm_lvfilesystem: "{{ filesystem }}"
+      when: "not (molecule_test | default(False))"
 
     # Disk Layout - OMERO | data dir
     - role: ome.lvm_partition
@@ -85,6 +84,7 @@
       lvm_lvmount: "{{ omero_common_basedir }}"
       lvm_lvsize: "{{ provision_omero_basedir_lvsize }}"
       lvm_lvfilesystem: "{{ filesystem }}"
+      when: "not (molecule_test | default(False))"
 
     #  Mock database user & creds, to allow Playbook to install
     #  OMERO, and allow for a manual PostgresSQL dump/restore.
@@ -96,19 +96,24 @@
         password: "{{ omero_server_dbpassword | default('omero') }}"
         databases:
           - "{{ omero_server_dbname | default('omero') }}"
+      postgresql_install_server: true
 
 
     # Note - had to have these set to `install-mock` to progress role
     # installation before changing config to restored DB from other system.
     - role: ome.omero_server
-      omero_server_release: 5.5.1
-      omero_server_datadir_manage: False
+      omero_server_release: 5.6.0
+      omero_server_datadir_manage: "{{ molecule_test | default(False) }}"
       omero_server_systemd_limit_nofile: 16384
-      omero_server_systemd_after:
-      - gpfs.service
-      omero_server_systemd_requires:
-      - gpfs.service
-      omero_server_system_user_manage: False
+      omero_server_systemd_after: >-
+        {{ molecule_test | default(False) | ternary([], ['gpfs.service']) }}
+      omero_server_systemd_requires: >-
+        {{ molecule_test | default(False) | ternary([], ['gpfs.service']) }}
+      omero_server_system_user_manage: "{{ molecule_test | default(False) }}"
+
+    # Current server proxies to a decoupled OMERO.web server
+    # Initially replicate this setup, to minimise changes.
+    - role: ome.nginx
 
     - role: ome.ssl_certificate
 
@@ -120,7 +125,7 @@
         name: nginx
         state: reloaded
 
-  post_tasks:
+  tasks:
     - name: NGINX - enable service / start on boot
       become: yes
       systemd:
@@ -134,6 +139,8 @@
         dest: "/etc/nginx/nginx.conf"
         regexp: '^worker_processes\s+\d+;'
         replace: "worker_processes 1;"
+      notify:
+        - restart nginx
 
     # post 2.3 'dest' should be renamed 'path'
     # cf https://www.digitalocean.com/community/tutorials/how-to-optimize-nginx-configuration
@@ -143,6 +150,8 @@
         dest: "/etc/nginx/nginx.conf"
         regexp: 'worker_connections\s+\d+;'
         replace: "worker_connections 65000;"
+      notify:
+        - restart nginx
 
     - name: NGINX - create nested includes directory
       become: yes
@@ -193,7 +202,7 @@
       tags: monitoring
       become: yes
       command: cp "{{ check_mk_agent_config_example_path }}/logwatch.cfg" "{{ check_mk_agent_config_path }}/logwatch.cfg" creates="{{ check_mk_agent_config_path }}/logwatch.cfg"
-      when: check_mk_logwatch_plugin_conf_st
+      when: check_mk_logwatch_plugin_conf_st.stat.exists
 
     - name: PostgreSQL Nightly Backups | Create the backups directory
       tags: backups
@@ -204,6 +213,7 @@
         owner: postgres
         group: postgres
         mode: "u=rwx,go="
+      when: "not (molecule_test | default(False))"
 
     - name: PostgreSQL Nightly Backups | send the backup script
       tags: backups
@@ -212,6 +222,7 @@
         src: nightly-pg_dump-omero.sh.j2
         dest: /etc/cron.daily/nightly-pg_dump-omero.sh
         mode: "u=rwx,go="
+      when: "not (molecule_test | default(False))"
 
     - name: Create a figure scripts directory
       become: yes
@@ -225,7 +236,7 @@
     - name: Download the Figure_To_Pdf.py script
       become: yes
       get_url:
-        url: https://raw.githubusercontent.com/ome/omero-figure/{{ omero_figure_release }}/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+        url: https://raw.githubusercontent.com/ome/omero-figure/v{{ omero_figure_release }}/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
         dest: /opt/omero/server/OMERO.server/lib/scripts/omero/figure_scripts/Figure_To_Pdf.py
         mode: 0644
         owner: root
@@ -245,29 +256,38 @@
     #omero_server_db_dumpdir_parent: /tmp
     #omero_server_db_dumpdir_name: nightly-pg_dump_omero.dir
 
-    ice_version: "3.6"
+    nginx_version: 1.16.1
     postgresql_version: "9.6"
     filesystem: "xfs"
-    omero_figure_release: "{{ omero_figure_release_override | default('v4.0.2') }}"
-    omero_server_config_set:
+    omero_figure_release: "{{ omero_figure_release_override | default('4.2.0') }}"
+
+    omero_web_config_set_production:
       omero.db.poolsize: 60
       omero.jvmcfg.percent.blitz: 50
       omero.jvmcfg.percent.indexer: 20
       omero.jvmcfg.percent.pixeldata: 20
       omero.jvmcfg.system_memory: 17000
-      omero.ldap.base: "{{ omero_server_ldap_base }}"
+      omero.ldap.base: "{{ omero_server_ldap_base | default('example') }}"
       omero.ldap.config: true
-      omero.ldap.urls: "{{ omero_server_ldap_urls }}"
+      omero.ldap.urls: "{{ omero_server_ldap_urls | default('ldap://example.org') }}"
       omero.mail.config: true
-      omero.mail.from: "{{ omero_server_mail_from }}"
-      omero.mail.host: "{{ omero_server_mail_host }}"
+      omero.mail.from: "{{ omero_server_mail_from | default('omero@example.org') }}"
+      omero.mail.host: "{{ omero_server_mail_host | default('smtp.example.org') }}"
       omero.ldap.new_user_group: "My Data"
       omero.search.batch: 100
       omero.security.password_provider: chainedPasswordProvider431
       omero.throttling.method_time.error: 60000
-      omero.Ice.Default.Host: "{{ omero_server_ice_default_host }}"
-      Ice.Admin.Endpoints: "{{ omero_server_ice_admin_endpoints }}"
-      omero.data.dir: "{{ omero_server_datadir  }}"
+      omero.Ice.Default.Host: "{{ omero_server_ice_default_host | default('127.0.0.1') }}"
+      Ice.Admin.Endpoints: "{{ omero_server_ice_admin_endpoints | default('tcp -h 127.0.0.1') }}"
+      omero.data.dir: "{{ omero_server_datadir | default('/OMERO') }}"
+
+    # Production config can't be tested in molecule
+    omero_server_config_set: "{{ molecule_test | default(False) | ternary({}, omero_web_config_set_production) }}"
+    omero_server_python_addons:
+      # For OMERO.figure script
+      - reportlab
+      - markdown
+
 
     # Disable SSL combined certificate and key
     ssl_certificate_combined_path: ''

--- a/requirements.yml
+++ b/requirements.yml
@@ -52,8 +52,9 @@
 - src: ome.omero_python_deps
   version: 2.0.1
 
-- src: ome.omero_server
-  version: 3.0.0
+- name: ome.omero_server
+  src: https://github.com/ome/ansible-role-omero-server/archive/b7a7a59f3dcf16cb8ed20068fb4a62d1b3365a64.tar.gz
+  version: b7a7a59f3dcf16cb8ed20068fb4a62d1b3365a64
 
 - src: ome.omero_user
   version: 0.1.2

--- a/requirements.yml
+++ b/requirements.yml
@@ -52,9 +52,8 @@
 - src: ome.omero_python_deps
   version: 2.0.1
 
-- name: ome.omero_server
-  src: https://github.com/ome/ansible-role-omero-server/archive/b7a7a59f3dcf16cb8ed20068fb4a62d1b3365a64.tar.gz
-  version: b7a7a59f3dcf16cb8ed20068fb4a62d1b3365a64
+- src: ome.omero_server
+  version: 3.1.0
 
 - src: ome.omero_user
   version: 0.1.2

--- a/requirements.yml
+++ b/requirements.yml
@@ -46,9 +46,8 @@
 - src: ome.basedeps
   version: 1.1.0
 
-- name: ome.omero_prometheus_exporter
-  src: https://github.com/manics/ansible-role-omero-prometheus-exporter/archive/cb4951496efd41e55575bd8dbb27173fb423be4a.tar.gz
-  version: cb4951496efd41e55575bd8dbb27173fb423be4a
+- src: ome.omero_prometheus_exporter
+  version: 0.3.0
 
 - src: ome.omero_python_deps
   version: 2.0.1
@@ -59,10 +58,8 @@
 - src: ome.omero_user
   version: 0.1.2
 
-# https://github.com/ome/ansible-role-omero-web/pull/35
-- name: ome.omero_web
-  src: https://github.com/manics/ansible-role-omero-web/archive/3a9266e90c0f307205d90ebd5b717ef13ee1a7c5.tar.gz
-  version: 3a9266e90c0f307205d90ebd5b717ef13ee1a7c5
+- src: ome.omero_web
+  version: 3.0.1
 
 # Delete this when everything is on Python 3
 - src: ome.omero_web_apps

--- a/requirements.yml
+++ b/requirements.yml
@@ -59,8 +59,10 @@
 - src: ome.omero_user
   version: 0.1.2
 
-- src: ome.omero_web
-  version: 3.0.0
+# https://github.com/ome/ansible-role-omero-web/pull/35
+- name: ome.omero_web
+  src: https://github.com/manics/ansible-role-omero-web/archive/3a9266e90c0f307205d90ebd5b717ef13ee1a7c5.tar.gz
+  version: 3a9266e90c0f307205d90ebd5b717ef13ee1a7c5
 
 # Delete this when everything is on Python 3
 - src: ome.omero_web_apps

--- a/templates/nginx-omero.conf.j2
+++ b/templates/nginx-omero.conf.j2
@@ -39,9 +39,9 @@ server {
     location / {
         error_page 502 @maintenance;
         # return 502;
-        # checks for static file, if not found proxy to {{ nginx_omero_web_server_address }}
+        # checks for static file, if not found proxy to nginx_omero_web_server_address
     
-        proxy_pass              {{ nginx_omero_web_server_address }};
+        proxy_pass              {{ nginx_omero_web_server_address | default('https://www.openmicroscopy.org/') }};
         proxy_set_header        Host $host;
         proxy_set_header        X-Real-IP $remote_addr;
         proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
5.6.0 Nightshade upgrade.

Also adds some molecule tests. The verify step of the webclient test currently hangs on Travis but passes locally, so is disabled. Previously there were no tests at all for these playbooks so this is still an improvement.