### PR TITLE
Add websocket connection motifs for outreach servers

### DIFF
--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -58,6 +58,43 @@
       notify:
       - restart omero-web
 
+    - name: OMERO.server self-signed certificate directory
+      become: yes
+      file:
+        path: /opt/omero/server/selfsigned
+        state: directory
+
+    - name: OMERO.server self-signed certificate
+      become: yes
+      command: >-
+        openssl req
+        -new -nodes -x509
+        {{ omero_server_websocket_internal_cert_params }}
+        -keyout server.key
+        -out server.pem
+        -extensions v3_ca
+      args:
+        chdir: /opt/omero/server/selfsigned
+        creates: server.pem
+
+    # This self-signed cert is used to encrypt the websocket connection
+    # between Nginx and OMERO.server
+    - name: OMERO.server self-signed certificate pkcs12
+      become: yes
+      command: >-
+        openssl pkcs12
+        -export
+        -out server.p12
+        -inkey server.key
+        -in server.pem
+        -name server
+        -password pass:{{
+        omero_server_config_set['omero.glacier2.IceSSL.Password'] | quote }}
+      args:
+        chdir: /opt/omero/server/selfsigned
+        creates: server.p12
+
+
   roles:
 
     - role: ome.postgresql
@@ -112,6 +149,22 @@
         line: '    include /etc/nginx/conf.d-nested-includes/*.conf;'
       notify:
       - restart nginx
+
+    - name: NGINX - OMERO websockets
+      become: yes
+      template:
+        src: templates/nginx-confdnestedincludes-omerows-conf.j2
+        dest: /etc/nginx/conf.d-nested-includes/omerows.conf
+      notify:
+        - restart nginx
+
+    - name: NGINX - websocket proxy support
+      become: yes
+      template:
+        src: templates/nginx-confd-websockets-conf.j2
+        dest: /etc/nginx/conf.d/websockets.conf
+      notify:
+        - restart nginx
 
     - name: Omero.web plugins | plugin install via pip & pypi
       become: yes
@@ -350,12 +403,19 @@
     ldap_password: "{{ ldap_password_override | default ('secret') }}"
     omero_server_config_set:
       #omero.fs.importUsers: "fm1"
+      omero.client.icetransports: ssl,wss,tcp
       omero.fs.watchDir: "/home/DropBox"
       omero.fs.importArgs: "-T \"regex:^.*/(?<Container1>.*?)\""
       omero.db.poolsize: 60
       omero.jvmcfg.percent.blitz: 50
       omero.jvmcfg.percent.indexer: 20
       omero.jvmcfg.percent.pixeldata: 20
+      omero.glacier2.IceSSL.Ciphers: "ADH:HIGH"
+      omero.glacier2.IceSSL.DefaultDir: /opt/omero/server/selfsigned
+      omero.glacier2.IceSSL.CAs: server.pem
+      omero.glacier2.IceSSL.CertFile: server.p12
+      # This password doesn't need to be secret
+      omero.glacier2.IceSSL.Password: secret
       omero.fs.repo.path: "%user%_%userId%/%thread%//%year%-%month%/%day%/%time%"
       omero.ldap.config: "true"
       omero.ldap.urls: "ldap://localhost:10389"
@@ -369,6 +429,9 @@
       omero.ldap.user_filter: "(objectClass=person)"
       omero.ldap.user_mapping: "omeName=uid,firstName=givenName,lastName=sn,email=mail"
       omero.ldap.username: "uid=admin,ou=system"
+
+    # OMERO.server internal SSL (only used for Nginx <-> OMERO.server traffic)
+    omero_server_websocket_internal_cert_params: '-subj "/C=UK/ST=Scotland/L=Dundee/O=OME/CN=localhost" -days 3650'
 
     external_nic: "{{ ansible_default_ipv4.interface }}"
 


### PR DESCRIPTION
After discussion with @jburel and @manics , this is motivated by the need to have a websocket connection to outreach servers for the next outreach session, to be able to use MyBinder.

This PR basically leans on https://github.com/ome/prod-playbooks/pull/204, trying to make similar changes for the outreach playbook as were done in https://github.com/ome/prod-playbooks/pull/204 for demo server.