### PR TITLE
Update the training backup jupyterhub server

### DIFF
--- a/jupyterhub/playbook.yml
+++ b/jupyterhub/playbook.yml
@@ -25,7 +25,7 @@
 
   roles:
 
-  - role: idr.idr-jupyter
+  - role: idr.idr_jupyter
     idr_jupyter_prefix: /training
     idr_jupyter_authenticator: tmpauthenticator.TmpAuthenticator
     idr_jupyter_cull_options:

--- a/jupyterhub/playbook.yml
+++ b/jupyterhub/playbook.yml
@@ -38,7 +38,7 @@
     # No admins
     idr_jupyter_admins: []
     #idr_jupyter_pull_latest: True
-    idr_jupyter_notebook_image: "{{ idr_jupyter_notebook_image_override | default('openmicroscopy/training-notebooks:0.4.1') }}"
+    idr_jupyter_notebook_image: "{{ idr_jupyter_notebook_image_override | default('openmicroscopy/training-notebooks:0.7.2') }}"
     idr_jupyter_additional_config:
       Spawner.mem_limit: 2G
 

--- a/molecule/jupyterhub/tests/test_default.py
+++ b/molecule/jupyterhub/tests/test_default.py
@@ -14,9 +14,6 @@ def test_services_running_and_enabled(host):
 def test_tmplogin(host):
     out = host.check_output(
         'curl --dump-header - -k https://localhost/training/hub/tmplogin')
-    pattern = re.compile(
-        r'location: /training/user/\w{8}-\w{4}-\w{4}-\w{4}-\w{12}')
-    assert any(pattern.search(line) for line in out.splitlines())
-
+    assert 'location: /training/hub/spawn' in out
 
 # TODO: check notebook container runs after login

--- a/molecule/jupyterhub/tests/test_default.py
+++ b/molecule/jupyterhub/tests/test_default.py
@@ -1,5 +1,4 @@
 import os
-import re
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(

--- a/requirements.yml
+++ b/requirements.yml
@@ -107,6 +107,5 @@
 - src: ome.versioncontrol_utils
   version: 1.0.2
 
-- name: idr.idr_jupyter
-  src: https://github.com/IDR/ansible-role-idr-jupyter/archive/50dedc7e093df8dc407d037badd78f487dd8d19e.tar.gz
-  version: 50dedc7e093df8dc407d037badd78f487dd8d19e
+- src: idr.idr_jupyter
+  version: 4.0.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -107,6 +107,6 @@
 - src: ome.versioncontrol_utils
   version: 1.0.2
 
-- name: idr.idr-jupyter
-  src: idr.ansible-role-idr-jupyter
-  version: 3.0.0
+- name: idr.idr_jupyter
+  src: https://github.com/IDR/ansible-role-idr-jupyter/archive/50dedc7e093df8dc407d037badd78f487dd8d19e.tar.gz
+  version: 50dedc7e093df8dc407d037badd78f487dd8d19e


### PR DESCRIPTION
Updates JupyterHub, see
- [x] https://github.com/IDR/ansible-role-idr-jupyter/pull/6

Updates the notebook image to `openmicroscopy/training-notebooks:0.7.2`