### PR TITLE
Upgrade outreach servers for new apps

### DIFF
--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -342,12 +342,12 @@
     omero_server_datadir_managedrepo_mode: u=rwX,g=srwX,o=rX,+t
     omero_server_datadir_chown: False
     omero_server_release: "{{ omero_server_release_override | default('5.6.0') }}"
-    omero_web_release: "{{ omero_web_release_override | default('5.6.1') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.6.2') }}"
     omero_figure_release: "{{ omero_figure_release_override | default('4.2.0') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"
-    omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.9.0') }}"
+    omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.9.1') }}"
     omero_mapr_release: "{{ omero_mapr_release_override | default('0.4') }}"
-    omero_parade_release: "{{ omero_parade_release_override | default('0.2.0') }}"
+    omero_parade_release: "{{ omero_parade_release_override | default('0.2.1') }}"
 
     # The omero_web_apps_* vars are used by the ome.omero_web role under
     # Python 3 otherwise ignored


### PR DESCRIPTION
These changes are deployed successfully on workshop, outreach and ome-training-4 servers. 


cc @manics @jburel 