### PR TITLE
Upgrade training servers

### DIFF
--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -341,8 +341,8 @@
     omero_server_system_managedrepo_group: managed_repo_group
     omero_server_datadir_managedrepo_mode: u=rwX,g=srwX,o=rX,+t
     omero_server_datadir_chown: False
-    omero_server_release: "{{ omero_server_release_override | default('5.6.0') }}"
-    omero_web_release: "{{ omero_web_release_override | default('5.6.2') }}"
+    omero_server_release: "{{ omero_server_release_override | default('5.6.1') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.6.3') }}"
     omero_figure_release: "{{ omero_figure_release_override | default('4.2.0') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"
     omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.9.1') }}"


### PR DESCRIPTION
Upgrade of omero and omero-web

cc @sbesson @manics @jburel 

I have upgraded successfully 

 - outreach
 - workshop
 - ome-training-4

I will wait with ome-training-3 upgrade until https://github.com/openmicroscopy/management_tools/pull/1180 is clarified.