### PR TITLE
Add public samples images for MetaXpress

### DIFF
--- a/release/group_vars/all.yml
+++ b/release/group_vars/all.yml
@@ -28,6 +28,7 @@ public_folders:
   leica-lif: 'Leica-LIF'
   leica-scn: 'Leica-SCN'
   leo: 'LEO'
+  metaxpress: 'MetaXpress'
   micromanager: 'Micro-Manager'
   mrc: 'MRC'
   nd2: 'ND2'


### PR DESCRIPTION
See also https://github.com/ome/bio-formats-documentation/pull/157

This should create a public folder under https://downloads.openmicroscopy.org/images/ for the public MetaXpress filesets in our curated QA repository /cc @melissalinkert 