### PR TITLE
training-server: activate omero-ms-zarr

### DIFF
--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -345,6 +345,8 @@
           -A POSTROUTING -o {{ external_nic }} -j MASQUERADE
           # Allow world to access 10389?
           -A INPUT -p tcp -m tcp --dport 10389 -s 0.0.0.0/0 -j ACCEPT
+          # Allow world to access 8080?
+          -A INPUT -p tcp -m tcp --dport 8080 -s 0.0.0.0/0 -j ACCEPT
         state: present
 
   # Crypted passwords generated using
@@ -387,7 +389,7 @@
     # or override it by defining the private variable os_system_users_password_override.
     os_system_users_password: "{{ os_system_users_password_override | default('$6$leKi5B1PgSvdA/ec$xbU3CnoSFnYdeZjEjKK5TH8SGATsW746uopssff4edpgyu.cWXGo9A.oK6wH9kIkxLCCNcORGZnnroZPMqGzN/') }}"
     apache_docker_release: "{{ apache_docker_release_override | default('0.6.0') }}"
-    omero_ms_zarr_release: "{{ omero_ms_zarr_release | default('latest') }}"
+    omero_ms_zarr_release: "{{ omero_ms_zarr_release_override | default('latest') }}"
     ldap_password: "{{ ldap_password_override | default ('secret') }}"
     omero_server_config_set:
       #omero.fs.importUsers: "fm1"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -319,8 +319,10 @@
         network_mode: host
         published_ports:
           - "8080:8080"
-        state: started
         restart_policy: always
+        state: started
+        volumes:
+          - "/OMERO:/OMERO:ro"
 
     # https://fralef.me/docker-and-iptables.html
     # https://blog.daknob.net/debian-firewall-docker/

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -114,13 +114,6 @@
         dest: /etc/nginx/conf.d/websockets.conf
       # Don't notify, nginx isn't installed yet
 
-    - name: NGINX - omero-ms-zarr support
-      become: yes
-      template:
-        src: ../../templates/nginx-confdnestedincludes-omero-ms-zarr.j2
-        dest: /etc/nginx/conf.d-nested-includes/omero-ms-zarr.conf
-      # Don't notify, nginx isn't installed yet
-
   roles:
 
     - role: ome.postgresql
@@ -323,12 +316,19 @@
           CONFIG_omero_db_name: omero
           CONFIG_omero_data_dir: /OMERO
         network_mode: host
-        exposed_ports: "8080"
-        published_ports: "8080:8080"
         restart_policy: always
         state: started
+        pull: yes
         volumes:
           - "/OMERO:/OMERO:ro"
+
+    - name: NGINX - omero-ms-zarr support
+      become: yes
+      template:
+        src: ../../templates/nginx-confdnestedincludes-omero-ms-zarr.j2
+        dest: /etc/nginx/conf.d-nested-includes/omero-ms-zarr.conf
+      notify:
+        - restart nginx
 
     # https://fralef.me/docker-and-iptables.html
     # https://blog.daknob.net/debian-firewall-docker/

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -114,6 +114,12 @@
         dest: /etc/nginx/conf.d/websockets.conf
       # Don't notify, nginx isn't installed yet
 
+    - name: NGINX - omero-ms-zarr support
+      become: yes
+      template:
+        src: ../../templates/nginx-confdnestedincludes-omero-ms-zarr.j2
+        dest: /etc/nginx/conf.d-nested-includes/omero-ms-zarr.conf
+      # Don't notify, nginx isn't installed yet
 
   roles:
 
@@ -317,8 +323,8 @@
           CONFIG_omero_db_name: omero
           CONFIG_omero_data_dir: /OMERO
         network_mode: host
-        published_ports:
-          - "8080:8080"
+        exposed_ports: "8080"
+        published_ports: "8080:8080"
         restart_policy: always
         state: started
         volumes:
@@ -348,8 +354,6 @@
           -A POSTROUTING -o {{ external_nic }} -j MASQUERADE
           # Allow world to access 10389?
           -A INPUT -p tcp -m tcp --dport 10389 -s 0.0.0.0/0 -j ACCEPT
-          # Allow world to access 8080?
-          -A INPUT -p tcp -m tcp --dport 8080 -s 0.0.0.0/0 -j ACCEPT
         state: present
 
   # Crypted passwords generated using

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -305,6 +305,22 @@
         state: started
         restart_policy: always
 
+    - name: Run docker for omero-ms-zarr
+      become: yes
+      docker_container:
+        image: openmicroscopy/omero-ms-zarr:{{ omero_ms_zarr_release }}
+        name: omero_ms_zarr
+        env:
+          CONFIG_omero_db_host: localhost
+          CONFIG_omero_db_user: omero
+          CONFIG_omero_db_pass: omero
+          CONFIG_omero_db_name: omero
+          CONFIG_omero_data_dir: /OMERO
+        published_ports:
+          - "8080:8080"
+        state: started
+        restart_policy: always
+
     # https://fralef.me/docker-and-iptables.html
     # https://blog.daknob.net/debian-firewall-docker/
     # Allow:
@@ -371,6 +387,7 @@
     # or override it by defining the private variable os_system_users_password_override.
     os_system_users_password: "{{ os_system_users_password_override | default('$6$leKi5B1PgSvdA/ec$xbU3CnoSFnYdeZjEjKK5TH8SGATsW746uopssff4edpgyu.cWXGo9A.oK6wH9kIkxLCCNcORGZnnroZPMqGzN/') }}"
     apache_docker_release: "{{ apache_docker_release_override | default('0.6.0') }}"
+    omero_ms_zarr_release: "{{ omero_ms_zarr_release | default('latest') }}"
     ldap_password: "{{ ldap_password_override | default ('secret') }}"
     omero_server_config_set:
       #omero.fs.importUsers: "fm1"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -316,6 +316,7 @@
           CONFIG_omero_db_pass: omero
           CONFIG_omero_db_name: omero
           CONFIG_omero_data_dir: /OMERO
+        network_mode: host
         published_ports:
           - "8080:8080"
         state: started

--- a/templates/nginx-confdnestedincludes-omero-ms-zarr.j2
+++ b/templates/nginx-confdnestedincludes-omero-ms-zarr.j2
@@ -1,7 +1,3 @@
 location /image {
     proxy_pass http://127.0.0.1:8080/image;
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $connection_upgrade;
-    proxy_read_timeout 86400;
 }

--- a/templates/nginx-confdnestedincludes-omero-ms-zarr.j2
+++ b/templates/nginx-confdnestedincludes-omero-ms-zarr.j2
@@ -1,0 +1,7 @@
+location /image {
+    proxy_pass http://127.0.0.1:8080/image;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_read_timeout 86400;
+}


### PR DESCRIPTION
This starts the latest docker image for omero-ms-zarr from Docker Hub, listening on port 8080. This will allow us to point notebooks and similar at:

```https://workshop.o.org:8080/image/$ID.zarr```

Suggestions for similar other configuration welcome. It is unclear how many concurrent users this single endpoint will be able to handle.

cc: @pwalczysko @mtbc @will-moore @jburel @manics