### PR TITLE
Upgrade OMERO.figure 4.3.1 on nightshade and dundeeomero

### DIFF
--- a/nightshade-webclients.yml
+++ b/nightshade-webclients.yml
@@ -114,7 +114,7 @@
       }}
 
     omero_web_release: "{{ omero_web_release_override | default('5.6.3') }}"
-    omero_figure_release: "{{ omero_figure_release_override | default('4.2.0') }}"
+    omero_figure_release: "{{ omero_figure_release_override | default('4.3.1') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"
     omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.9.1') }}"
     omero_parade_release: "{{ omero_parade_release_override | default('0.2.1') }}"

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -268,7 +268,7 @@
     nginx_version: 1.16.1
     postgresql_version: "9.6"
     filesystem: "xfs"
-    omero_figure_release: "{{ omero_figure_release_override | default('4.2.0') }}"
+    omero_figure_release: "{{ omero_figure_release_override | default('4.3.1') }}"
 
     omero_server_config_set_production:
       omero.db.poolsize: 60


### PR DESCRIPTION
Re: https://lists.openmicroscopy.org.uk/mailman/private/nightshade-support/2020-June/002924.html

Bug has been fixed in 4.3.0.
Latest is 4.3.1.