### PR TITLE
Demo 5.6.2 upgrade

### DIFF
--- a/learning.yml
+++ b/learning.yml
@@ -21,7 +21,6 @@
       lvm_shrink: False
 
     - role: ome.postgresql
-      postgresql_install_server: True
       postgresql_databases:
         - name: omero
       postgresql_users:

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -132,7 +132,6 @@
 
     - role: ome.postgresql
       #no_log: true
-      postgresql_install_server: True
       postgresql_databases:
         - name: omero
       postgresql_users:

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -355,17 +355,17 @@
 
   vars:
     django_cors_headers_release: "{{ django_cors_headers_release_override | default('2.5.3') }}"
-    omero_figure_release: "{{ omero_figure_release_override | default('4.3.0') }}"
+    omero_figure_release: "{{ omero_figure_release_override | default('4.3.1') }}"
     omero_figure_script_release: "{{ omero_figure_script_release_override | default('v4.2.0') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"
-    omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.9.1') }}"
+    omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.10.0') }}"
     omero_parade_release: "{{ omero_parade_release_override | default('0.2.1') }}"
     omero_webtagging_autotag_release: "{{ omero_webtagging_autotag_release_override | default('3.1.0') }}"
     omero_webtagging_tagsearch_release: "{{ omero_webtagging_tagsearch_release_override | default('3.1.0') }}"
     omero_signup_release: "{{ omero_signup_release_override | default('0.2.2') }}"
 
-    omero_server_release: "{{ omero_server_release_override | default('5.6.1') }}"
-    omero_web_release: "{{ omero_web_release_override | default('5.6.3') }}"
+    omero_server_release: "{{ omero_server_release_override | default('5.6.2') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.7.0') }}"
     # For https://github.com/openmicroscopy/ansible-role-java, which is a dependency.
     java_jdk_install: True
 

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -96,7 +96,6 @@
         password: "{{ omero_server_dbpassword | default('omero') }}"
         databases:
           - "{{ omero_server_dbname | default('omero') }}"
-      postgresql_install_server: true
 
 
     # Note - had to have these set to `install-mock` to progress role

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -123,7 +123,6 @@
       - user: omero
         password: omero
         databases: [omero]
-      postgresql_install_server: true
 
     - role: ome.versioncontrol_utils
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -38,10 +38,10 @@
   version: 1.2.1
 
 - src: ome.omego
-  version: 0.1.3
+  version: 0.2.0
 
 - src: ome.omero_common
-  version: 0.1.0
+  version: 0.3.2
 
 - src: ome.basedeps
   version: 1.1.0
@@ -53,13 +53,13 @@
   version: 2.0.1
 
 - src: ome.omero_server
-  version: 3.1.0
+  version: 3.3.0
 
 - src: ome.omero_user
-  version: 0.1.2
+  version: 0.2.0
 
 - src: ome.omero_web
-  version: 3.0.1
+  version: 3.1.0
 
 # Delete this when everything is on Python 3
 - src: ome.omero_web_apps
@@ -69,10 +69,13 @@
   version: 0.3.0
 
 - src: ome.postgresql
-  version: 3.3.1
+  version: 5.0.1
 
 - src: ome.postgresql_backup
   version: 0.1.1
+
+- src: ome.postgresql_client
+  version: 0.1.2
 
 - src: ome.prometheus
   version: 0.3.1

--- a/sls-gallery.yml
+++ b/sls-gallery.yml
@@ -19,7 +19,6 @@
       lvm_shrink: False
 
     - role: ome.postgresql
-      postgresql_install_server: True
       postgresql_databases:
         - name: omero
       postgresql_users:


### PR DESCRIPTION
Prepares the upgrade of the demo servers to the latest released OMERO components - see https://www.openmicroscopy.org/2020/07/16/omero-5-6-2.html

As discussed earlier with @mtbc @manics @will-moore, also includes an upgrade of the OMERO Ansible roles to their latest versions including the updates to the `ome.postgresql` variables across all production playbooks.