### PR TITLE
SLS Gallery upgrade.

### DIFF
--- a/sls-gallery.yml
+++ b/sls-gallery.yml
@@ -155,7 +155,7 @@
         - omero-web
 
   vars:
-    omero_server_release: 5.6.1
-    omero_web_release: 5.6.3
+    omero_server_release: 5.6.2
+    omero_web_release: 5.7.0
     omero_web_apps_release:
-      omero_iviewer: 0.9.1
+      omero_iviewer: 0.10.0


### PR DESCRIPTION
Now deployed.

Curiously, had to restart omero-web manually for the upgraded version to be running.