### PR TITLE
Add nginx_version to the public web-proxy playbook

### DIFF
--- a/web-proxy/playbook.yml
+++ b/web-proxy/playbook.yml
@@ -20,6 +20,9 @@
   - role: ome.ssl_certificate
   - role: ome.nginx_proxy
 
+  vars:
+    nginx_version: 1.18.0
+
   handlers:
     - name: reload nginx
       listen: ssl certificate changed

--- a/web-proxy/playbook.yml
+++ b/web-proxy/playbook.yml
@@ -20,9 +20,6 @@
   - role: ome.ssl_certificate
   - role: ome.nginx_proxy
 
-  vars:
-    nginx_version: 1.18.0
-
   handlers:
     - name: reload nginx
       listen: ssl certificate changed
@@ -30,3 +27,6 @@
       service:
         name: nginx
         state: reloaded
+
+  vars:
+    nginx_version: 1.18.0


### PR DESCRIPTION
This version was managed privately previously. This PR migrates it to the public playbooks similarly to the other web deployments