### PR TITLE
Bump PostgreSQL version to 11 on OME demo server playbook

### DIFF
--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -383,7 +383,7 @@
     omero_cli_render_release: "{{ omero_cli_render_release_override | default('0.5.0') }}"
     omero_metadata_release: "{{ omero_cli_metadata_release_override | default('0.5.0') }}"
 
-    postgresql_version: "9.6"
+    postgresql_version: "11"
     filesystem: "xfs"
 
     omero_server_config_set:

--- a/requirements.yml
+++ b/requirements.yml
@@ -61,6 +61,9 @@
 - src: ome.omero_web
   version: 3.1.0
 
+- src: ome.python3_virtualenv
+  version: 0.1.1
+
 # Delete this when everything is on Python 3
 - src: ome.omero_web_apps
   version: 0.3.0


### PR DESCRIPTION
As discussed this morning, this will manually require a dump of the DB, an installation + uninstallation of the current PSQL and a restore of the DB.

To be tested on `pub-omero` first