### PR TITLE
ome.prometheus_postgres 0.4.0

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -90,7 +90,7 @@
   version: 0.2.1
 
 - src: ome.prometheus_postgres
-  version: 0.2.1
+  version: 0.4.0
 
 - src: ome.redis
   version: 1.1.1


### PR DESCRIPTION
Closes https://github.com/ome/prod-playbooks/issues/281

The `omero/omero-monitoring-agents.yml` playbook has been run against `staging-hosts`