### PR TITLE
Replace nightshade pg cronjob with ome.postgresql_backup

### DIFF
--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -184,8 +184,7 @@
       tags: ssl
 
     - role: ome.postgresql_backup
-      postgresql_backup_dir: >-
-        {{ omero_server_db_dumpdir_parent | default('/tmp/pgbackup') }}
+      postgresql_backup_dir: /OMERO/pgbackup
       postgresql_backup_filename_format: "nightly-omero-%a.pgdump"
       postgresql_backup_minimum_expected_size: 1000000000
 

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -183,6 +183,12 @@
     - role: ome.ssl_certificate
       tags: ssl
 
+    - role: ome.postgresql_backup
+      postgresql_backup_dir: >-
+        {{ omero_server_db_dumpdir_parent | default('/tmp/pgbackup') }}
+      postgresql_backup_filename_format: "nightly-omero-%a.pgdump"
+      postgresql_backup_minimum_expected_size: 1000000000
+
   handlers:
     - name: reload web server
       listen: ssl certificate changed
@@ -318,21 +324,11 @@
       command: cp "{{ check_mk_agent_config_example_path }}/logwatch.cfg" "{{ check_mk_agent_config_path }}/logwatch.cfg" creates="{{ check_mk_agent_config_path }}/logwatch.cfg"
       when: check_mk_logwatch_plugin_conf_st.stat.exists
 
-    - name: PostgreSQL Nightly Backups | Create the backups directory
+    - name: PostgreSQL Nightly Backups | Remove old cron job
       become: yes
       file:
-        path: "{{ omero_server_db_dumpdir_parent }}/{{ omero_server_db_dumpdir_name }}"
-        state: directory
-        owner: postgres
-        group: postgres
-        mode: "u=rwx,go="
-
-    - name: PostgreSQL Nightly Backups | send the backup script
-      become: yes
-      template:
-        src: nightly-pg_dump-omero.sh.j2
-        dest: /etc/cron.daily/nightly-pg_dump-omero.sh
-        mode: "u=rwx,go="
+        path: /etc/cron.daily/nightly-pg_dump-omero.sh
+        state: absent
 
     - name: Create a figure scripts directory
       become: yes
@@ -373,10 +369,6 @@
     check_mk_agent_plugin_path: /usr/share/check-mk-agent/available-plugins
     check_mk_agent_config_example_path: /usr/share/check_mk/agents/cfg_examples
     check_mk_agent_config_path: /etc/check-mk-agent
-
-    # Backup folder for PostgreSQL 'folder' format dump
-    omero_server_db_dumpdir_parent: /tmp
-    omero_server_db_dumpdir_name: nightly-pg_dump_omero.dir
 
     # Pip versions
     omero_cli_duplicate_release: "{{ omero_cli_duplicate_release_override | default('0.3.0') }}"

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -184,9 +184,10 @@
       tags: ssl
 
     - role: ome.postgresql_backup
+      postgresql_backup_compress: true
       postgresql_backup_dir: /OMERO/pgbackup
-      postgresql_backup_filename_format: "nightly-omero-%a.pgdump"
-      postgresql_backup_minimum_expected_size: 1000000000
+      postgresql_backup_filename_format: "nightly-omero-%a.pgdump.gz"
+      postgresql_backup_minimum_expected_size: 100000000
 
   handlers:
     - name: reload web server

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -117,10 +117,11 @@
     - role: ome.ssl_certificate
 
     - role: ome.postgresql_backup
+      postgresql_backup_compress: true
       postgresql_backup_dir: >-
         {{ omero_server_db_dumpdir_parent | default('/tmp/pgbackup') }}
-      postgresql_backup_filename_format: "nightly-omero-%a.pgdump"
-      postgresql_backup_minimum_expected_size: 1000000000
+      postgresql_backup_filename_format: "nightly-omero-%a.pgdump.gz"
+      postgresql_backup_minimum_expected_size: 100000000
 
 
   handlers:

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -117,7 +117,8 @@
     - role: ome.ssl_certificate
 
     - role: ome.postgresql_backup
-      postgresql_backup_dir: "{{ omero_server_db_dumpdir_parent | default('/tmp') }}"
+      postgresql_backup_dir: >-
+        {{ omero_server_db_dumpdir_parent | default('/tmp/pgbackup') }}
       postgresql_backup_filename_format: "nightly-omero-%a.pgdump"
       postgresql_backup_minimum_expected_size: 1000000000
 

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -116,6 +116,12 @@
 
     - role: ome.ssl_certificate
 
+    - role: ome.postgresql_backup
+      postgresql_backup_dir: "{{ omero_server_db_dumpdir_parent | default('/tmp') }}"
+      postgresql_backup_filename_format: "nightly-omero-%a.pgdump"
+      postgresql_backup_minimum_expected_size: 1000000000
+
+
   handlers:
     - name: reload nginx
       listen: ssl certificate changed
@@ -212,25 +218,11 @@
       command: cp "{{ check_mk_agent_config_example_path }}/logwatch.cfg" "{{ check_mk_agent_config_path }}/logwatch.cfg" creates="{{ check_mk_agent_config_path }}/logwatch.cfg"
       when: check_mk_logwatch_plugin_conf_st.stat.exists
 
-    - name: PostgreSQL Nightly Backups | Create the backups directory
-      tags: backups
+    - name: PostgreSQL Nightly Backups | Remove old cron job
       become: yes
       file:
-        path: "{{ omero_server_db_dumpdir_parent }}/{{ omero_server_db_dumpdir_name }}"
-        state: directory
-        owner: postgres
-        group: postgres
-        mode: "u=rwx,go="
-      when: "not (molecule_test | default(False))"
-
-    - name: PostgreSQL Nightly Backups | send the backup script
-      tags: backups
-      become: yes
-      template:
-        src: nightly-pg_dump-omero.sh.j2
-        dest: /etc/cron.daily/nightly-pg_dump-omero.sh
-        mode: "u=rwx,go="
-      when: "not (molecule_test | default(False))"
+        path: /etc/cron.daily/nightly-pg_dump-omero.sh
+        state: absent
 
     - name: Create a figure scripts directory
       become: yes
@@ -258,11 +250,6 @@
     check_mk_agent_plugin_path: /usr/share/check-mk-agent/available-plugins
     check_mk_agent_config_example_path: /usr/share/check_mk/agents/cfg_examples
     check_mk_agent_config_path: /etc/check-mk-agent
-
-    # Backup folder for PostgreSQL 'folder' format dump
-    # Overriden by host vars, example values:
-    #omero_server_db_dumpdir_parent: /tmp
-    #omero_server_db_dumpdir_name: nightly-pg_dump_omero.dir
 
     nginx_version: 1.18.0
     postgresql_version: "9.6"

--- a/requirements.yml
+++ b/requirements.yml
@@ -74,9 +74,8 @@
 - src: ome.postgresql
   version: 5.0.1
 
-- name: ome.postgresql_backup
-  src: https://github.com/ome/ansible-role-postgresql-backup/archive/acd03814b8b5dd891451407b28820bfbd4fadbc5.tar.gz
-  version: pr5
+- src: ome.postgresql_backup
+  version: 0.2.0
 
 - src: ome.postgresql_client
   version: 0.1.2

--- a/requirements.yml
+++ b/requirements.yml
@@ -74,8 +74,9 @@
 - src: ome.postgresql
   version: 5.0.1
 
-- src: ome.postgresql_backup
-  version: 0.1.1
+- name: ome.postgresql_backup
+  src: https://github.com/ome/ansible-role-postgresql-backup/archive/acd03814b8b5dd891451407b28820bfbd4fadbc5.tar.gz
+  version: pr5
 
 - src: ome.postgresql_client
   version: 0.1.2

--- a/templates/nightly-pg_dump-omero.sh.j2
+++ b/templates/nightly-pg_dump-omero.sh.j2
@@ -1,5 +1,0 @@
-#!/bin/sh
-# Clean the files from the folder-format dump directory 
-rm {{ omero_server_db_dumpdir_parent }}/{{ omero_server_db_dumpdir_name }}/* 
-# Create a fresh db dump
-su - postgres -c 'pg_dump -j {{ (ansible_processor_count * ansible_processor_cores) |round|int }} -Fd -f {{ omero_server_db_dumpdir_parent }}/{{ omero_server_db_dumpdir_name }} omero'


### PR DESCRIPTION
Recently we discovered the current pgdump directory format may lead to loss of the previous backup if an error occurs during the current backup.

This replaces the custom cron job with the [ome.postgresql_backup role](https://github.com/ome/ansible-role-postgresql-backup) as used in https://github.com/ome/prod-playbooks/blob/2afc0764391e467411745946b5577973d7fa5625/k8s/postgres/playbook.yml#L25-L28

Note this role dumps all databases