### PR TITLE
Upgrade server and apps on training servers

### DIFF
--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -365,11 +365,11 @@
     omero_server_system_managedrepo_group: managed_repo_group
     omero_server_datadir_managedrepo_mode: u=rwX,g=srwX,o=rX,+t
     omero_server_datadir_chown: False
-    omero_server_release: "{{ omero_server_release_override | default('5.6.1') }}"
-    omero_web_release: "{{ omero_web_release_override | default('5.6.3') }}"
-    omero_figure_release: "{{ omero_figure_release_override | default('4.3.0') }}"
+    omero_server_release: "{{ omero_server_release_override | default('5.6.2') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.8.0') }}"
+    omero_figure_release: "{{ omero_figure_release_override | default('4.3.2') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"
-    omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.9.1') }}"
+    omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.10.1') }}"
     omero_mapr_release: "{{ omero_mapr_release_override | default('0.4') }}"
     omero_parade_release: "{{ omero_parade_release_override | default('0.2.1') }}"
 
@@ -389,7 +389,7 @@
     omero_webtagging_tagsearch_release: "{{ omero_webtagging_tagsearch_release_override | default('3.1.0') }}"
     omero_cli_duplicate_release: "{{ omero_cli_duplicate_release_override | default('0.3.0') }}"
     omero_metadata_release: "{{ omero_metadata_release_overrride | default('0.5.0') }}"
-    omero_cli_render_release: "{{ omero_cli_render_release_override | default('0.5.0') }}"
+    omero_cli_render_release: "{{ omero_cli_render_release_override | default('0.6.1') }}"
     # The os_system_users_password default is "ome".
     # You may wish to change this variable,
     # or override it by defining the private variable os_system_users_password_override.


### PR DESCRIPTION
Upgrading omero and apps on the outreach server.

Successfully upgraded

  - ome-training-4
  - outreach
  - workshop


cc @manics @sbesson 

ToDo" Upgrade ome-training-3 - but this needs to be done on top of https://github.com/openmicroscopy/management_tools/pull/1180, so will finish that one off tomorrow

