### PR TITLE
Bump ome-dundee PostgreSQL version to 11

### DIFF
--- a/molecule/ome-dundeeomero/tests/test_default.py
+++ b/molecule/ome-dundeeomero/tests/test_default.py
@@ -12,7 +12,7 @@ OMERO_LOGIN = '-C -s localhost -u root -w omero'
 @pytest.mark.parametrize("name", [
     'nginx',
     'omero-server',
-    'postgresql-9.6',
+    'postgresql-11',
     'prometheus-node-exporter',
     'prometheus-omero-exporter',
     'prometheus-postgres-exporter',

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -265,7 +265,7 @@
     #omero_server_db_dumpdir_name: nightly-pg_dump_omero.dir
 
     nginx_version: 1.18.0
-    postgresql_version: "9.6"
+    postgresql_version: "11"
     filesystem: "xfs"
     omero_figure_release: "{{ omero_figure_release_override | default('4.3.1') }}"
 


### PR DESCRIPTION
Proposed upgrade workflow (tested on `pub-omero`)

- [x] stop the server manually to prevent new DB entries `sudo service omero-server stop`
- [x]  dump the DB as `postgres`

      bash-4.2$ time pg_dump -j 4 -Fd -f /uod/idr/nightshade/backups/nightshade-20200922-      dump_omero.dir/ omero

      real	5m57.268s
      user	9m49.028s
      sys	0m14.928s

- [x] make a copy of the 9.6 database
  
        [root@ome-dundeeomero nightshade]#  time tar -czvf /uod/idr/nightshade/nightshade-varlibpgsql-20200922.tar.gz /var/lib/pgsql/9.6/
        ...
        real    43m48.535s
user    39m59.934s
sys     2m12.884s

- [x] delete the PSQL 9.6 packages  `sudo yum remove postgresql*`
- [x] install PSQL 11 and initialize the PSQL database: `ansible-playbook -K ome-dundeeomero.yml` up to `ome.postgresql`
- [x] delete the 9.6 database `rm -rf /var/lib/pgsql/9.6`
- [x] restore the DB as `postgres`: `pg_restore -h localhost -U omero-x -j 4 -Fd -d omero /uod/idr/nightshade/backups/nightshade-20200922-dump_omero.dir/`
- [x] re-deploy the server using `sudo service omero-server start` and `ansible-playbook -K ome-dundeeomero.yml`
- [ ] delete the 9.6 copy once the upgrade has been verified `rm -rf /tmp/psql_9.6`