### PR TITLE
Bump install release versions for SLS Gallery.

### DIFF
--- a/sls-gallery.yml
+++ b/sls-gallery.yml
@@ -155,7 +155,7 @@
         - omero-web
 
   vars:
-    omero_server_release: 5.6.2
-    omero_web_release: 5.7.0
+    omero_server_release: 5.6.3
+    omero_web_release: 5.8.1
     omero_web_apps_release:
-      omero_iviewer: 0.10.0
+      omero_iviewer: 0.10.1


### PR DESCRIPTION
Ready to deploy now OMERO 5.6.3 is released.