### PR TITLE
Bump install release versions for demo servers.

### DIFF
--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -47,7 +47,7 @@
     - name: OMERO.server self-signed certificate directory
       become: yes
       file:
-        path: /opt/omero/server/selfsigned
+        path: "{{ omero_server_basedir }}/selfsigned"
         state: directory
 
     - name: OMERO.server self-signed certificate
@@ -60,7 +60,7 @@
         -out server.pem
         -extensions v3_ca
       args:
-        chdir: /opt/omero/server/selfsigned
+        chdir: "{{ omero_server_basedir }}/selfsigned"
         creates: server.pem
 
     # This self-signed cert is used to encrypt the websocket connection
@@ -77,7 +77,7 @@
         -password pass:{{
         omero_server_config_set['omero.glacier2.IceSSL.Password'] | quote }}
       args:
-        chdir: /opt/omero/server/selfsigned
+        chdir: "{{ omero_server_basedir }}/selfsigned"
         creates: server.p12
 
   roles:
@@ -164,7 +164,7 @@
     # This role only works on OMERO 5.3+
     - role: ome.omero_user
       no_log: true
-      omero_user_bin_omero: /opt/omero/server/OMERO.server/bin/omero
+      omero_user_bin_omero: "{{ omero_server_basedir }}/OMERO.server/bin/omero"
       omero_user_system: omero-server
       omero_user_admin_user: root
       omero_user_admin_pass: "{{ omero_server_rootpassword }}"
@@ -338,7 +338,7 @@
     - name: Create a figure scripts directory
       become: yes
       file:
-        path: /opt/omero/server/OMERO.server/lib/scripts/omero/figure_scripts
+        path: "{{ omero_server_basedir }}/OMERO.server/lib/scripts/omero/figure_scripts"
         state: directory
         mode: 0755
         recurse: yes
@@ -348,7 +348,7 @@
       become: yes
       get_url:
         url: https://raw.githubusercontent.com/ome/omero-figure/{{ omero_figure_script_release }}/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
-        dest: /opt/omero/server/OMERO.server/lib/scripts/omero/figure_scripts/Figure_To_Pdf.py
+        dest: "{{ omero_server_basedir }}/OMERO.server/lib/scripts/omero/figure_scripts/Figure_To_Pdf.py"
         mode: 0755
         owner: "omero-server"
         group: "omero-server"
@@ -391,7 +391,7 @@
       omero.client.icetransports: ssl,wss,tcp
       omero.db.poolsize: 60
       omero.glacier2.IceSSL.Ciphers: "ADH:HIGH"
-      omero.glacier2.IceSSL.DefaultDir: /opt/omero/server/selfsigned
+      omero.glacier2.IceSSL.DefaultDir: "{{ omero_server_basedir }}/selfsigned"
       omero.glacier2.IceSSL.CAs: server.pem
       omero.glacier2.IceSSL.CertFile: server.p12
       # This password doesn't need to be secret

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -355,17 +355,17 @@
 
   vars:
     django_cors_headers_release: "{{ django_cors_headers_release_override | default('2.5.3') }}"
-    omero_figure_release: "{{ omero_figure_release_override | default('4.3.1') }}"
+    omero_figure_release: "{{ omero_figure_release_override | default('4.3.2') }}"
     omero_figure_script_release: "{{ omero_figure_script_release_override | default('v4.3.2') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"
     omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.10.1') }}"
     omero_parade_release: "{{ omero_parade_release_override | default('0.2.1') }}"
     omero_webtagging_autotag_release: "{{ omero_webtagging_autotag_release_override | default('3.1.0') }}"
     omero_webtagging_tagsearch_release: "{{ omero_webtagging_tagsearch_release_override | default('3.1.0') }}"
-    omero_signup_release: "{{ omero_signup_release_override | default('0.2.2') }}"
+    omero_signup_release: "{{ omero_signup_release_override | default('0.2.3') }}"
 
-    omero_server_release: "{{ omero_server_release_override | default('5.6.2') }}"
-    omero_web_release: "{{ omero_web_release_override | default('5.8.0') }}"
+    omero_server_release: "{{ omero_server_release_override | default('5.6.3') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.8.1') }}"
     # For https://github.com/openmicroscopy/ansible-role-java, which is a dependency.
     java_jdk_install: True
 
@@ -379,8 +379,8 @@
     omero_server_db_dumpdir_name: nightly-pg_dump_omero.dir
 
     # Pip versions
-    omero_cli_duplicate_release: "{{ omero_cli_duplicate_release_override | default('0.3.0') }}"
-    omero_cli_render_release: "{{ omero_cli_render_release_override | default('0.5.0') }}"
+    omero_cli_duplicate_release: "{{ omero_cli_duplicate_release_override | default('0.4.0') }}"
+    omero_cli_render_release: "{{ omero_cli_render_release_override | default('0.6.1') }}"
     omero_metadata_release: "{{ omero_cli_metadata_release_override | default('0.5.0') }}"
 
     postgresql_version: "11"

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -196,6 +196,7 @@
     - name: Omero.cli plugins | plugin install via pip & pypi
       become: yes
       pip:
+        executable: "{{ omero_server_basedir }}/venv3/bin/pip"
         name:
         - "omero-cli-duplicate=={{ omero_cli_duplicate_release }}"
         - "omero-cli-render=={{ omero_cli_render_release }}"


### PR DESCRIPTION
Ready to deploy now OMERO 5.6.3 is released.