### PR TITLE
Upgrade outreach servers for OMERO 563

### DIFF
--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -387,7 +387,7 @@
     ome_training_scripts_release: "{{ ome_training_scripts_release_override | default('0.7.1') }}"
     omero_webtagging_autotag_release: "{{ omero_webtagging_autotag_release_override | default('3.1.0') }}"
     omero_webtagging_tagsearch_release: "{{ omero_webtagging_tagsearch_release_override | default('3.1.0') }}"
-    omero_cli_duplicate_release: "{{ omero_cli_duplicate_release_override | default('0.3.0') }}"
+    omero_cli_duplicate_release: "{{ omero_cli_duplicate_release_override | default('0.4.0') }}"
     omero_metadata_release: "{{ omero_metadata_release_overrride | default('0.5.0') }}"
     omero_cli_render_release: "{{ omero_cli_render_release_override | default('0.6.1') }}"
     # The os_system_users_password default is "ome".

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -365,8 +365,8 @@
     omero_server_system_managedrepo_group: managed_repo_group
     omero_server_datadir_managedrepo_mode: u=rwX,g=srwX,o=rX,+t
     omero_server_datadir_chown: False
-    omero_server_release: "{{ omero_server_release_override | default('5.6.2') }}"
-    omero_web_release: "{{ omero_web_release_override | default('5.8.0') }}"
+    omero_server_release: "{{ omero_server_release_override | default('5.6.3') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.8.1') }}"
     omero_figure_release: "{{ omero_figure_release_override | default('4.3.2') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"
     omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.10.1') }}"


### PR DESCRIPTION
Upgrades

  - OMERO to 5.6.3
  - OMERO.web to 5.8.1

These changes were successfully deployed on following servers


   - ome-training-3  and 4
   - workshop
   - outreach


cc @sbesson 