### PR TITLE
fixes typo in variable name -  https_letsencrypt_enabled

### DIFF
--- a/omero/training-server/letsencrypt.yml
+++ b/omero/training-server/letsencrypt.yml
@@ -78,4 +78,4 @@
     # This must match the expectations of certbot, do not change this:
     https_letsencrypt_cert_path: "/etc/letsencrypt/live/{{ https_certificate_domain | default('localhost') }}"
     # In production set this to True:
-    # https_lets_encrypt_enabled:
+    # https_letsencrypt_enabled:


### PR DESCRIPTION
I noticed that the variable name at the end of the script has an underscore, while the actual variable that is checked in the script to conditionally run doesn't have an underscore. So, uncommenting the line at the end of the script and setting it to True doesn't actually do anything.