### PR TITLE
Replace ome.deploy_archive by deployment script to update the static website

### DIFF
--- a/www/files/deploy
+++ b/www/files/deploy
@@ -68,7 +68,7 @@ def main(version, parent, dry_run):
         # Mutator
         os.symlink(dst, sym)
         print('Symlinked {} to {}'.format(dst, sym))
-    sys.exit(0)
+    sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/www/files/deploy
+++ b/www/files/deploy
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+import argparse
+import json
+import os
+import sys
+import tarfile
+# Python 2 and 3 compatible so this can be run on RHEL7 without a virtualenv
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
+
+
+def main(version, parent, dry_run):
+    # https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#releases
+    # No paging, assume no-one will install a really old version
+    r = urlopen('https://api.github.com/repos/ome/www.openmicroscopy.org/releases')
+    assert r.code == 200
+    releases = json.load(r)
+
+    if version == 'latest':
+        release = releases[0]
+    else:
+        release = None
+        for check in releases:
+            if check['tag_name'] == version:
+                release = check
+                break
+        if release is None:
+            print('Failed to find release {}'.format(version))
+            sys.exit(1)
+
+    tag = release['tag_name']
+
+    dst = os.path.join(parent, tag)
+    sym = os.path.join(parent, 'html')
+
+    if os.path.exists(dst):
+        print('{} already exists, not downloading'.format(dst))
+    elif dry_run:
+        print('Would download {}'.format(dst))
+    else:
+        www_assets = [a for a in release['assets'] if a['name'] == 'www.openmicroscopy.org.tar.gz']
+        assert len(www_assets) == 1, 'Expected one asset named www.openmicroscopy.org.tar.gz'
+        url = www_assets[0]['browser_download_url']
+
+        h = urlopen(url)
+        thetarfile = tarfile.open(fileobj=h, mode="r|gz")
+        thetarfile.extractall(path=dst)
+        h.close()
+        print('Extracted {} to {}'.format(url, dst))
+
+    if os.path.exists(sym):
+        assert os.path.islink(sym), '{} is not a symlink'.format(sym)
+        target = os.readlink(sym)
+        if target == dst:
+            print('{} already points to {}, no changes made'.format(dst, sym))
+            sys.exit(0)
+        elif dry_run:
+            print('Would remove symlink {} (target={})'.format(sym, target))
+        else:
+            print(target)
+            # Mutator
+            os.remove(sym)
+    if dry_run:
+        print('Would symlink {} to {}'.format(dst, sym))
+    else:
+        # Mutator
+        os.symlink(dst, sym)
+        print('Symlinked {} to {}'.format(dst, sym))
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    xor = parser.add_mutually_exclusive_group()
+    xor.add_argument('-n','--dry-run', action='store_true', default=True)
+    xor.add_argument('-f','--force', action='store_false', dest="dry_run")
+    parser.add_argument(
+        '--parentdir', default='/var/www/www.openmicroscopy.org',
+        help='Web-server directory for www.openmicroscopy.org')
+    parser.add_argument('--version', default='latest',
+        help='Release to download')
+    args = parser.parse_args()
+    main(args.version, args.parentdir, args.dry_run)

--- a/www/playbook.yml
+++ b/www/playbook.yml
@@ -60,6 +60,10 @@
       when: "'10.1.255.216' in ansible_dns.nameservers"
 
     - role: ome.sudoers
+      sudoers_individual_commands:
+      - user: "%omedev"
+        become: ALL
+        command: "NOPASSWD: /usr/local/bin/deploy *"
 
   post_tasks:
 

--- a/www/www-static.yml
+++ b/www/www-static.yml
@@ -29,7 +29,8 @@
     become: yes
     command: /usr/local/bin/deploy -f
     register: deploy_result
-    changed_when: '"Symlinked" in deploy_result.stdout'
+    changed_when: 'deploy_result.rc==1'
+    failed_when: 'deploy_result.rc>1'
 
   - name: Update static phpbb stylesheet
     become: yes

--- a/www/www-static.yml
+++ b/www/www-static.yml
@@ -27,8 +27,9 @@
 
   - name: run deployment script
     become: yes
-    command: /usr/local/bin/deploy -f
+    command: /usr/local/bin/deploy {{ ansible_check_mode | ternary('-n', '-f') }}
     register: deploy_result
+    check_mode: no
     changed_when: 'deploy_result.rc==1'
     failed_when: 'deploy_result.rc>1'
 

--- a/www/www-static.yml
+++ b/www/www-static.yml
@@ -11,17 +11,6 @@
   roles:
   - role: ome.deploy_archive
     become: yes
-    deploy_archive_dest_dir: /var/www/{{ website_name }}/{{ website_version }}
-    deploy_archive_src_url: https://github.com/ome/{{ website_name }}/releases/download/{{ website_version }}/{{ website_name }}.tar.gz
-    # Optional checksum. It should be safe to omit as long as you never
-    # overwrite an existing archive. This should not be a problem when using
-    # versioned directories.
-    deploy_archive_sha256: "{{ website_sha256 }}"
-    deploy_archive_symlink: /var/www/{{ website_name }}/html
-    tags: jekyll
-
-  - role: ome.deploy_archive
-    become: yes
     deploy_archive_dest_dir: /var/www
     deploy_archive_src_url: https://downloads.openmicroscopy.org/web-archive/phpbbforum-20190718.tar.gz
     deploy_archive_sha256: e9d7a7eefbacf42ddbdf92b201584913cb6d94ec331750f811232b2e91aa5b40
@@ -29,6 +18,19 @@
     when: not _phpbbforum_style_file_st.stat.exists
 
   tasks:
+  - name: install deployment script
+    become: yes
+    template:
+      src: files/deploy
+      dest: /usr/local/bin/deploy
+      mode: 0555
+
+  - name: run deployment script
+    become: yes
+    command: /usr/local/bin/deploy -f
+    register: deploy_result
+    changed_when: '"Symlinked" in deploy_result.stdout'
+
   - name: Update static phpbb stylesheet
     become: yes
     blockinfile:
@@ -48,8 +50,4 @@
       path: "{{ phpbbforum_style_file }}"
 
   vars:
-    website_version: "2020.12.08-1"
-    website_sha256: >-
-      cc18ea048ab4c796d766aa7adec555abe5eb1e4db605af29a83669a13701eb6e
-    website_name: www.openmicroscopy.org
     phpbbforum_style_file: "/var/www/phpbbforum/www.openmicroscopy.org/community/style.php?id=7&lang=en"


### PR DESCRIPTION
Ports the script proposed and tested in https://github.com/ome/www.openmicroscopy.org/pull/426 to the Ansible playbook for updating the www server

This should remove the constant requirement to update the playbook variable as we release the website.

The script is installed under `/usr/local/bin/deploy` and should be executable as a standalone by anyone with sudo permissions.