### PR TITLE
Use idr.redmine_tracker from Ansible Galaxy

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -117,6 +117,5 @@
 - src: idr.idr_jupyter
   version: 4.0.0
 
-- name: idr.redmine_tracker
-  src: https://github.com/IDR/ansible-role-redmine-tracker/archive/0.1.0.tar.gz
+- src: idr.redmine_tracker
   version: 0.1.0


### PR DESCRIPTION
Following the publication of the role to https://galaxy.ansible.com/idr/redmine_tracker