### PR TITLE
Add omero-grafana-json-datasource

### DIFF
--- a/omedev/docker-prod-apps.yml
+++ b/omedev/docker-prod-apps.yml
@@ -251,6 +251,7 @@
       docker_container:
         image: grafana/grafana:7.2.0
         env:
+          GF_INSTALL_PLUGINS: grafana-simple-json-datasource
           GF_SERVER_ROOT_URL: '%(protocol)s://%(domain)s:%(http_port)s/grafana/'
           GF_SERVER_SERVE_FROM_SUB_PATH: 'true'
         name: grafana
@@ -261,6 +262,16 @@
         volumes:
           - grafana-data:/var/lib/grafana
       register: _grafana_container
+
+    - name: Run docker omero grafana json datasource
+      become: true
+      docker_container:
+        image: registry.gitlab.com/openmicroscopy/incubator/omero-grafana-json-datasource:0.1.1
+        name: omero-grafana-ds
+        networks:
+          - name: monitoring
+        state: started
+        restart_policy: always
 
     - name: prometheus htpasswd parent directory
       become: true


### PR DESCRIPTION
https://github.com/ome/kubernetes-apps/blob/555d9be273f3130dacb7d3b0da00d1abb41dddd8/omero-grafana-ds/generic-webapp.yml

Doesn't actually work at the moment, neither here, nor on the old K8s monitoring system. Probably an update somewhere broke it.