### PR TITLE
Remove NGOM mount point from ome-dundeeomero playbook

### DIFF
--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -12,28 +12,6 @@
            and (ansible_virtualization_type == "VMware"))
            and not (molecule_test | default(False))
 
-    # Not required for an OMERO server install - UoD specific implementation
-    - name: NGOM mount point | Install NFS prerequisites
-      become: yes
-      yum:
-        name: nfs-utils
-        state: present
-
-    # Not required for an OMERO server install - UoD specific implementation
-    # Before Ansible 2.3, option 'name' was used instead of 'path'
-    - name: NGOM mount point | Create the fstab entry and mount the fs
-      tags: lvm
-      become: yes
-      mount:
-        name: /ngom
-        state: mounted
-        fstype: nfs
-        src: "{{ ngom_nfs_server_addr }}:/uod/lfs/ngom"
-        opts: tcp,rsize=16384,wsize=16384
-        dump: 0
-        passno: 0
-      when: "not (molecule_test | default(False))"
-
     # Perhaps alter the role at https://github.com/openmicroscopy/ansible-role-lvm-partition/
     # to make some of the variables non-required.
     - name: Resize root FS without altering mount options


### PR DESCRIPTION
This mount point had been previously created to test some processing pipelines but has not been used.
After discussion with @graemeball, proposing to remove this from the deployment playbook. If this becomes useful again, we can come back to this effort.