### PR TITLE
Upgrade omero-web, figure and iviewer

### DIFF
--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -421,7 +421,7 @@
     omero_server_datadir_managedrepo_mode: u=rwX,g=srwX,o=rX,+t
     omero_server_datadir_chown: False
     omero_server_release: "{{ omero_server_release_override | default('5.6.3') }}"
-    omero_web_release: "{{ omero_web_release_override | default('5.9.0') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.9.1') }}"
     omero_figure_release: "{{ omero_figure_release_override | default('4.4.0') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"
     omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.10.2') }}"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -421,10 +421,10 @@
     omero_server_datadir_managedrepo_mode: u=rwX,g=srwX,o=rX,+t
     omero_server_datadir_chown: False
     omero_server_release: "{{ omero_server_release_override | default('5.6.3') }}"
-    omero_web_release: "{{ omero_web_release_override | default('5.8.1') }}"
-    omero_figure_release: "{{ omero_figure_release_override | default('4.3.2') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.9.0') }}"
+    omero_figure_release: "{{ omero_figure_release_override | default('4.4.0') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"
-    omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.10.1') }}"
+    omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.10.2') }}"
     omero_mapr_release: "{{ omero_mapr_release_override | default('0.4') }}"
     omero_parade_release: "{{ omero_parade_release_override | default('0.2.1') }}"
 


### PR DESCRIPTION
Upgrading all training servers with

   - OMERO.web 5.9.0
   - OMERO.figure 4.4.0
   - OMERO.iviewer 0.10.2
  

Run successfully on 

  - outreach
  - workshop
  - ome-training-3
  - ome-training-4
 

cc @sbesson @jburel 

Edit: Also the second upgrade to OMERO.web 5.9.1 was successfully done on all fourn training servers.