### PR TITLE
Add cron job for auto-deploying the OME website

### DIFF
--- a/www/www-static.yml
+++ b/www/www-static.yml
@@ -25,13 +25,12 @@
       dest: /usr/local/bin/deploy
       mode: 0555
 
-  - name: run deployment script
+  - name: Add cron job updating the website
     become: yes
-    command: /usr/local/bin/deploy {{ ansible_check_mode | ternary('-n', '-f') }}
-    register: deploy_result
-    check_mode: no
-    changed_when: 'deploy_result.rc==1'
-    failed_when: 'deploy_result.rc>1'
+    cron:
+      name: "Deploy the website"
+      special_time: hourly
+      job: "/usr/local/bin/deploy 2>&1 > /dev/null || /usr/local/bin/deploy -f"
 
   - name: Update static phpbb stylesheet
     become: yes

--- a/www/www-static.yml
+++ b/www/www-static.yml
@@ -25,6 +25,12 @@
       dest: /usr/local/bin/deploy
       mode: 0555
 
+  - name: Install Cron daemon
+    become: yes
+    yum:
+     name: cronie
+     state: installed
+
   - name: Add cron job updating the website
     become: yes
     cron:


### PR DESCRIPTION
Attempts to reduce the number of  steps required to update the OME website - see https://ome-contributing.readthedocs.io/en/latest/jekyll.html#id1

Rather than having to run a manual deployment command post tagging of the website, this installs a cron job which runs hourly and tries to update the website if a new version is installed. The deploy script can still be executed manually.