### PR TITLE
OMERO playbooks: upgrade roles and install certificates

### DIFF
--- a/learning.yml
+++ b/learning.yml
@@ -71,6 +71,7 @@
         omero.security.keyStorePassword: "changeit"
         omero.security.trustStorePassword: "changeit"
         omero.sessions.timeout: 3600000
+      omero_server_selfsigned_certificates: True
 
     - role: ome.redis
 

--- a/molecule/ome-dundeeomero/molecule.yml
+++ b/molecule/ome-dundeeomero/molecule.yml
@@ -29,7 +29,6 @@ provisioner:
       all:
         molecule_test: true
       docker-hosts:
-        omero_server_systemd_require_network: False
         # firewalld isn't installed, don't attempt to disable
         iptables_raw_disable_firewalld: False
   playbooks:

--- a/molecule/omero-training-server/molecule.yml
+++ b/molecule/omero-training-server/molecule.yml
@@ -27,7 +27,6 @@ provisioner:
         molecule_test: True
         postgresql_version: "9.6"
       docker-hosts:
-        omero_server_systemd_require_network: False
         # This should allow docker-in-docker to work
         docker_storage_driver: vfs
         # Latest version 17.12.1.ce-1.el7.centos has a bug that prevents

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -161,16 +161,6 @@
 
   post_tasks:
 
-    - name: Omero.cli plugins | plugin install via pip & pypi
-      become: yes
-      pip:
-        executable: "{{ omero_server_basedir }}/venv3/bin/pip"
-        name:
-        - "omero-cli-duplicate=={{ omero_cli_duplicate_release }}"
-        - "omero-cli-render=={{ omero_cli_render_release }}"
-        - "omero-metadata=={{ omero_metadata_release }}"
-        state: present
-
     - name: NGINX - Performance tuning - worker processes
       become: yes
       replace:
@@ -388,6 +378,9 @@
       omero.throttling.method_time.error: 60000
 
     omero_server_python_addons:
+      - "omero-cli-duplicate=={{ omero_cli_duplicate_release }}"
+      - "omero-cli-render=={{ omero_cli_render_release }}"
+      - "omero-metadata=={{ omero_metadata_release }}"
       # For OMERO.figure script
       - reportlab
       - markdown

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -44,43 +44,6 @@
       with_items:
         - mencoder # For the 'make movie' script
 
-    - name: OMERO.server self-signed certificate directory
-      become: yes
-      file:
-        path: "{{ omero_server_basedir }}/selfsigned"
-        state: directory
-        mode: 0755
-
-    - name: OMERO.server self-signed certificate
-      become: yes
-      command: >-
-        openssl req
-        -new -nodes -x509
-        {{ omero_server_websocket_internal_cert_params }}
-        -keyout server.key
-        -out server.pem
-        -extensions v3_ca
-      args:
-        chdir: "{{ omero_server_basedir }}/selfsigned"
-        creates: server.pem
-
-    # This self-signed cert is used to encrypt the websocket connection
-    # between Nginx and OMERO.server
-    - name: OMERO.server self-signed certificate pkcs12
-      become: yes
-      command: >-
-        openssl pkcs12
-        -export
-        -out server.p12
-        -inkey server.key
-        -in server.pem
-        -name server
-        -password pass:{{
-        omero_server_config_set['omero.glacier2.IceSSL.Password'] | quote }}
-      args:
-        chdir: "{{ omero_server_basedir }}/selfsigned"
-        creates: server.p12
-
   roles:
     # Now OME are using RHEL without Spacewalk, the current best-method of
     # checking `is server deployed in Dundee/SLS` is checking for the SLS nameservers.
@@ -404,6 +367,7 @@
     filesystem: "xfs"
 
     omero_server_config_set:
+      omero.certificates.owner: "/C=UK/ST=Scotland/L=Dundee/O=OME"
       omero.client.icetransports: ssl,wss,tcp
       omero.db.poolsize: 60
       omero.glacier2.IceSSL.Ciphers: "ADH:HIGH"
@@ -428,6 +392,8 @@
       - reportlab
       - markdown
 
+    omero_server_selfsigned_certificates: True
+
     omero_web_config_set:
       omero.mail.config: true
       omero.mail.from: "{{ omero_server_mail_from }}"
@@ -449,6 +415,3 @@
 
     # Disable SSL combined certificate and key
     ssl_certificate_combined_path: ''
-
-    # OMERO.server internal SSL (only used for Nginx <-> OMERO.server traffic)
-    omero_server_websocket_internal_cert_params: '-subj "/C=UK/ST=Scotland/L=Dundee/O=OME/CN=localhost" -days 3650'

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -162,10 +162,8 @@
         - "omero-signup=={{ omero_signup_release }}"
         - "django-cors-headers=={{ django_cors_headers_release }}"
 
-    # This role only works on OMERO 5.3+
     - role: ome.omero_user
       no_log: true
-      omero_user_bin_omero: "{{ omero_server_basedir }}/OMERO.server/bin/omero"
       omero_user_system: omero-server
       omero_user_admin_user: root
       omero_user_admin_pass: "{{ omero_server_rootpassword }}"

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -261,6 +261,8 @@
       Ice.Admin.Endpoints: "{{ omero_server_ice_admin_endpoints | default('tcp -h 127.0.0.1') }}"
       omero.data.dir: "{{ omero_server_datadir | default('/OMERO') }}"
 
+    omero_server_selfsigned_certificates: True
+
     # Production config can't be tested in molecule
     omero_server_config_set: "{{ molecule_test | default(False) | ternary({}, omero_server_config_set_production) }}"
     omero_server_python_addons:

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -31,29 +31,6 @@
         - gcc
         - python-ldap
 
-    - name: Delete broken Python 3 web app configuration
-      become: yes
-      file:
-        path: "{{ omero_web_basedir }}/config/{{ item }}"
-        state: absent
-      when: 'omero_web_python3 | default(False)'
-      with_items:
-        - omero-web-outreach-webapps.omero
-        - django-prometheus.omero
-        - gunicorn-config.py
-      notify:
-      - restart omero-web
-
-    # This separate file has been redundant for ages
-    # https://github.com/ome/prod-playbooks/blob/142d8c675c56d465686e792eb6d69668e408e537/templates/omero-web-config-for-webapps.j2#L19
-    - name: Remove old configuration file
-      become: yes
-      file:
-        path: "{{ omero_web_basedir }}/config/omero-web-config-default-viewer.omero"
-        state: absent
-      notify:
-      - restart omero-web
-
     # Since Nginx isn't installed until later the directories are created in advance
     - name: Create nginx include directories
       become: yes

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -131,7 +131,6 @@
     - role: ome.nfs_mount
 
     - role: ome.omero_server
-      omero_server_virtualenv: yes
       omero_server_python_addons:
         - "omero-cli-duplicate=={{ omero_cli_duplicate_release }}"
         - "omero-cli-render=={{ omero_cli_render_release }}"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -54,49 +54,6 @@
       notify:
       - restart omero-web
 
-    - name: OMERO.server self-signed certificate directory
-      become: yes
-      file:
-        path: /opt/omero/server/selfsigned
-        state: directory
-        mode: 0755
-
-    - name: OMERO.server install openssl for generating certificates
-      become: yes
-      yum:
-        name: openssl
-        state: present
-
-    - name: OMERO.server self-signed certificate
-      become: yes
-      command: >-
-        openssl req
-        -new -nodes -x509
-        {{ omero_server_websocket_internal_cert_params }}
-        -keyout server.key
-        -out server.pem
-        -extensions v3_ca
-      args:
-        chdir: /opt/omero/server/selfsigned
-        creates: server.pem
-
-    # This self-signed cert is used to encrypt the websocket connection
-    # between Nginx and OMERO.server
-    - name: OMERO.server self-signed certificate pkcs12
-      become: yes
-      command: >-
-        openssl pkcs12
-        -export
-        -out server.p12
-        -inkey server.key
-        -in server.pem
-        -name server
-        -password pass:{{
-        omero_server_config_set['omero.glacier2.IceSSL.Password'] | quote }}
-      args:
-        chdir: /opt/omero/server/selfsigned
-        creates: server.p12
-
     # Since Nginx isn't installed until later the directories are created in advance
     - name: Create nginx include directories
       become: yes
@@ -416,6 +373,7 @@
     #temporal upgrade force for omero server workaround
     #omero_server_checkupgrade_comparator: '!='
     postgresql_version: "10"
+    omero_server_selfsigned_certificates: True
     omero_server_system_managedrepo_group: managed_repo_group
     omero_server_datadir_managedrepo_mode: u=rwX,g=srwX,o=rX,+t
     omero_server_datadir_chown: False
@@ -451,6 +409,7 @@
     ldap_password: "{{ ldap_password_override | default ('secret') }}"
     omero_server_config_set:
       #omero.fs.importUsers: "fm1"
+      omero.certificates.owner: "/C=UK/ST=Scotland/L=Dundee/O=OME"
       omero.client.icetransports: ssl,wss,tcp
       omero.fs.watchDir: "/home/DropBox"
       omero.fs.importArgs: "-T \"regex:^.*/(?<Container1>.*?)\""
@@ -477,9 +436,6 @@
       omero.ldap.user_filter: "(objectClass=person)"
       omero.ldap.user_mapping: "omeName=uid,firstName=givenName,lastName=sn,email=mail"
       omero.ldap.username: "uid=admin,ou=system"
-
-    # OMERO.server internal SSL (only used for Nginx <-> OMERO.server traffic)
-    omero_server_websocket_internal_cert_params: '-subj "/C=UK/ST=Scotland/L=Dundee/O=OME/CN=localhost" -days 3650'
 
     omero_web_config_set:
       omero.web.nginx_server_extra_config:

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -110,28 +110,6 @@
     - role: ome.cli_utils
 
   tasks:
-
-    - name: Omero.web plugins | plugin install via pip & pypi
-      become: yes
-      pip:
-        # name: "{{ omero_web_apps_packages }}"
-        name:
-        - "omero-figure=={{ omero_figure_release }}"
-        - "omero-fpbioimage=={{ omero_fpbioimage_release }}"
-        - "omero-iviewer=={{ omero_iviewer_release }}"
-        - "omero-mapr=={{ omero_mapr_release }}"
-        - "omero-parade=={{ omero_parade_release }}"
-        - "omero-webtagging-autotag=={{ omero_webtagging_autotag_release }}"
-        - "omero-webtagging-tagsearch=={{ omero_webtagging_tagsearch_release }}"
-        editable: False
-        state: present
-        # variable comes from role openmicroscopy.omero-web
-        virtualenv: "{{ omero_web_basedir }}/venv"
-        virtualenv_site_packages: yes
-      when: 'not (omero_web_python3 | default(False))'
-      notify:
-        - restart omero-web
-
     - name: Docker | python client
       become: yes
       yum:

--- a/requirements.yml
+++ b/requirements.yml
@@ -8,89 +8,79 @@
   version: 1.1.0
 
 - src: ome.deploy_archive
-  version: 0.1.3
+  version: 0.1.4
 
 - src: ome.docker
-  version: 3.1.0
+  version: 3.1.1
 
 - src: ome.ice
-  version: 4.0.0
+  version: 4.3.0
 
 - src: ome.java
-  version: 2.0.3
+  version: 2.1.0
 
 - name: ome.iptables_raw
-  version: 0.2.1
+  version: 0.3.1
 
 - src: ome.lvm_partition
   version: 1.1.1
 
 - name: ome.network
-  version: 1.1.3
+  version: 1.1.4
 
 - src: ome.nginx
-  version: 2.1.0
+  version: 2.1.1
 
 - src: ome.nginx_proxy
-  version: 1.15.0
+  version: 1.15.1
 
 - src: ome.nfs_mount
-  version: 1.2.1
-
-- src: ome.omego
-  version: 0.2.0
+  version: 1.3.0
 
 - src: ome.omero_common
-  version: 0.3.2
+  version: 0.3.4
 
 - src: ome.basedeps
-  version: 1.1.0
+  version: 1.2.0
 
 - src: ome.omero_prometheus_exporter
-  version: 0.3.0
-
-- src: ome.omero_python_deps
-  version: 2.0.1
+  version: 0.3.1
 
 - src: ome.omero_server
-  version: 3.3.0
+  version: 4.0.1
 
 - src: ome.omero_user
-  version: 0.2.0
+  version: 0.3.0
 
 - src: ome.omero_web
-  version: 3.1.0
+  version: 4.0.0
 
 - src: ome.python3_virtualenv
-  version: 0.1.1
-
-# Delete this when everything is on Python 3
-- src: ome.omero_web_apps
-  version: 0.3.0
+  version: 0.1.2
 
 - src: ome.omero_web_django_prometheus
   version: 0.3.0
 
 - src: ome.postgresql
-  version: 5.0.1
+  version: 5.0.2
 
 - src: ome.postgresql_backup
-  version: 0.2.0
+  version: 0.2.1
 
 - src: ome.postgresql_client
   version: 0.1.2
 
 - src: ome.prometheus
-  version: 0.5.0
+  version: 0.5.1
 
 - src: ome.prometheus_jmx
-  version: 0.2.1
+  version: 0.2.2
 
 - src: ome.prometheus_node
-  version: 0.2.1
+  version: 0.2.2
 
 - src: ome.prometheus_postgres
-  version: 0.4.0
+  version: 0.4.2
 
 - src: ome.redis
   version: 1.1.1
@@ -99,16 +89,16 @@
   version: 1.0.3
 
 - src: ome.ssl_certificate
-  version: 0.3.2
+  version: 0.3.3
 
 - src: ome.sudoers
-  version: 1.0.2
+  version: 1.0.3
 
 - src: ome.system_monitor_agent
   version: 0.1.1
 
 - src: ome.upgrade_distpackages
-  version: 1.1.1
+  version: 1.1.3
 
 - src: ome.versioncontrol_utils
   version: 1.0.2

--- a/sls-gallery.yml
+++ b/sls-gallery.yml
@@ -69,6 +69,7 @@
         omero.security.trustStore: "/etc/pki/java/cacerts"
         omero.security.keyStorePassword: "changeit"
         omero.security.trustStorePassword: "changeit"
+      omero_server_selfsigned_certificates: True
 
     - role: ome.redis
 


### PR DESCRIPTION
## Ansible role version bumps

Brings most roles inline with the latest release versions

### Minor version increments

- ome.ice: [4.0.0 -> 4.3.0](https://github.com/ome/ansible-role-ice/compare/4.0.0...4.3.0): Ubuntu/CentOS8 support, `ice-runtime` cleanup
- ome.java: [2.0.3 -> 2.1.0](https://github.com/ome/ansible-role-java/compare/2.0.3...2.1.0): `java_version` variable
- ome.baseps: [1.1.0 -> 1.2.0](https://github.com/ome/ansible-role-basedeps/compare/1.1.0...1.2.0): `curl` 


### Major version increments

- ome.iptables_raw: [0.2.1 -> 0.3.1](https://github.com/ome/ansible-role-iptables-raw/compare/0.2.1...0.3.0): additional checks (requires Ansible 2.6+)
- ome.omero_server: [3.3.0 -> 4.0.1](https://github.com/ome/ansible-role-omero-server/compare/3.3.0...1.2.0): (Python 2 dropped)
- ome.omero_user: [0.2.0 -> 0.3.0](https://github.com/ome/ansible-role-omero-user/compare/0.2.0...0.3.0): change default value of `omero_user_bin_omero`
- ome.omero_web: [3.1.0 -> 4.0.0](https://github.com/ome/ansible-role-basedeps/compare/3.1.0...4.0.0): (Python 2 dropped)

## Playbook changes

- uses `omero_server_selfsigned_certificates: True` to handle OpenJDK version dropping TLS 1.0/1.1 support
- remove redundant tasks setting up self-signed certificates on `omero-training` and `ome-demoserver`
- remove legacy Web app and plugin installation tasks in favor of the new `ome.omero_server` and `ome.omero_web` variables

## Testing

### Deployment 
This PR has been tested in check-mode then executed against `ome-training-3`, `pub-omero` and `sls-repo`. The relevant changes are

<details>
 <summary>ome-training</summary>

  ````diff
TASK [ome.postgresql : postgres | postgresql config file] ***********************************************************************************************************************************************************
--- before
+++ after
@@ -1,4 +1,4 @@
 {
-    "mode": "0654",
+    "mode": "0640",
     "path": "/var/lib/pgsql/10/data/postgresql.conf"
 }

changed: [ome-training-3.openmicroscopy.org]

TASK [ome.postgresql : postgres | configure client authorisation] ***************************************************************************************************************************************************
--- before
+++ after
@@ -1,4 +1,4 @@
 {
-    "mode": "0654",
+    "mode": "0640",
     "path": "/var/lib/pgsql/10/data/pg_hba.conf"
 }

changed: [ome-training-3.openmicroscopy.org]
TASK [ome.omero_server : omero server | configuration 00-omero-server.omero] ****************************************************************************************************************************************
--- before: /opt/omero/server/config/00-omero-server.omero
+++ after: /Users/sbesson/.ansible/tmp/ansible-local-30900trhsomlx/tmpksstr9lx/00-omero-server-omero.j2
@@ -10,6 +10,7 @@
 config set omero.data.dir /OMERO
 
 # Additional custom options
+config set -- omero.certificates.owner /C=UK/ST=Scotland/L=Dundee/O=OME
 config set -- omero.client.icetransports ssl,wss,tcp
 config set -- omero.db.poolsize 60
 config set -- omero.fs.importArgs '-T "regex:^.*/(?<Container1>.*?)"'
@@ -35,3 +36,5 @@
 config set -- omero.ldap.user_filter '(objectClass=person)'
 config set -- omero.ldap.user_mapping omeName=uid,firstName=givenName,lastName=sn,email=mail
 config set -- omero.ldap.username uid=admin,ou=system
+
+certificates -v

changed: [ome-training-3.openmicroscopy.org]
TASK [ome.omero_server : omero server | create omero server wrapper] ************************************************************************************************************************************************
--- before: /opt/omero/server/OMERO.server/bin/omero
+++ after: /Users/sbesson/.ansible/tmp/ansible-local-30900trhsomlx/tmp7a36l7p2/bin-omero.j2
@@ -7,10 +7,16 @@
 if not os.getenv('OMERODIR'):
     os.environ['OMERODIR'] = '/opt/omero/server/OMERO.server'
 
-current_path = os.getenv('PATH', '')
+paths = os.getenv('PATH', '').split(os.pathsep)
 venv_bin = '/opt/omero/server/venv3/bin'
-if not current_path.startswith(venv_bin + os.pathsep):
-    os.environ['PATH'] = '{}{}{}'.format(venv_bin, os.pathsep, current_path)
+ice_bin = '/opt/ice/bin'
+
+if os.path.isdir(ice_bin) and ice_bin not in paths:
+    paths.insert(0, ice_bin)
+if venv_bin not in paths:
+    paths.insert(0, venv_bin)
+
+os.environ['PATH'] = os.pathsep.join(paths)
 
 p = run(['/opt/omero/server/venv3/bin/omero'] + sys.argv[1:])
 sys.exit(p.returncode)

changed: [ome-training-3.openmicroscopy.org]
TASK [ome.omero_server : omero server | systemd service] ************************************************************************************************************************************************************
--- before: /etc/systemd/system/omero-server.service
+++ after: /Users/sbesson/.ansible/tmp/ansible-local-30900trhsomlx/tmpw3eu34bh/systemd-system-omero-server-service.j2
@@ -8,7 +8,6 @@
 After=postgresql-9.6.service
 After=postgresql-10.service
 After=postgresql-11.service
-Requires=network.service
 After=network.service
 
 [Service]

changed: [ome-training-3.openmicroscopy.org]
RUNNING HANDLER [ome.postgresql : restart postgresql] ***************************************************************************************************************************************************************
changed: [ome-training-3.openmicroscopy.org]
RUNNING HANDLER [ome.omero_common : reload systemd] *****************************************************************************************************************************************************************
changed: [ome-training-3.openmicroscopy.org]

RUNNING HANDLER [ome.omero_server : omero-server rewrite omero-server configuration] ********************************************************************************************************************************
changed: [ome-training-3.openmicroscopy.org]

RUNNING HANDLER [ome.omero_server : omero-server restart omero-server] **********************************************************************************************************************************************
changed: [ome-training-3.openmicroscopy.org]
TASK [Run docker for omero-ms-zarr] *********************************************************************************************************************************************************************************
--- before
+++ after
@@ -1,4 +1,4 @@
 {
-    "image": "sha256:19cd8dfd4c44222acd5c70cd08930a947d22d3df24c49a44ed989a171a62a98f",
+    "image": "sha256:7e3d8a30a3468415c6e27792a60b0d9b45c0412cd2c3042e66befca718df6d4e",
     "running": true
 }

changed: [ome-training-3.openmicroscopy.org]
PLAY RECAP **********************************************************************************************************************************************************************************************************
ome-training-3.openmicroscopy.org : ok=136  changed=10   unreachable=0    failed=0    skipped=85   rescued=0    ignored=0   
 ````
</details>


<details>
 <summary>ome-demoserver</summary>

  ````diff
TASK [ome.postgresql : postgres | postgresql config file] ***********************************************************************************************************************************************************
--- before
+++ after
@@ -1,4 +1,4 @@
 {
-    "mode": "0654",
+    "mode": "0640",
     "path": "/var/lib/pgsql/11/data/postgresql.conf"
 }

changed: [pub-omero.openmicroscopy.org]

TASK [ome.postgresql : postgres | configure client authorisation] ***************************************************************************************************************************************************
--- before
+++ after
@@ -1,4 +1,4 @@
 {
-    "mode": "0654",
+    "mode": "0640",
     "path": "/var/lib/pgsql/11/data/pg_hba.conf"
 }

changed: [pub-omero.openmicroscopy.org]
TASK [ome.omero_server : omero server | configuration 00-omero-server.omero] ****************************************************************************************************************************************
--- before: /opt/omero/server/config/00-omero-server.omero
+++ after: /Users/sbesson/.ansible/tmp/ansible-local-35210ishkfhud/tmp4smb4me_/00-omero-server-omero.j2
@@ -10,6 +10,7 @@
 config set omero.data.dir /OMERO
 
 # Additional custom options
+config set -- omero.certificates.owner /C=UK/ST=Scotland/L=Dundee/O=OME
 config set -- omero.client.icetransports ssl,wss,tcp
 config set -- omero.db.poolsize 60
 config set -- omero.glacier2.IceSSL.CAs server.pem
@@ -28,3 +29,4 @@
 config set -- omero.search.batch 100
 config set -- omero.throttling.method_time.error 60000
 
+certificates -v

changed: [pub-omero.openmicroscopy.org]
TASK [ome.omero_server : omero server | systemd service] ************************************************************************************************************************************************************
--- before: /etc/systemd/system/omero-server.service
+++ after: /Users/sbesson/.ansible/tmp/ansible-local-35210ishkfhud/tmpamz1b6jj/systemd-system-omero-server-service.j2
@@ -8,7 +8,6 @@
 After=postgresql-9.6.service
 After=postgresql-10.service
 After=postgresql-11.service
-Requires=network.service
 After=network.service
 
 [Service]

changed: [pub-omero.openmicroscopy.org]
[WARNING]: flush_handlers task does not support when conditional


RUNNING HANDLER [ome.postgresql : restart postgresql] ***************************************************************************************************************************************************************
changed: [pub-omero.openmicroscopy.org]

RUNNING HANDLER [ome.omero_common : reload systemd] *****************************************************************************************************************************************************************
changed: [pub-omero.openmicroscopy.org]

RUNNING HANDLER [ome.omero_server : omero-server rewrite omero-server configuration] ********************************************************************************************************************************
changed: [pub-omero.openmicroscopy.org]

RUNNING HANDLER [ome.omero_server : omero-server restart omero-server] **********************************************************************************************************************************************
changed: [pub-omero.openmicroscopy.org]
TASK [Create a figure scripts directory] ****************************************************************************************************************************************************************************
changed: [pub-omero.openmicroscopy.org]

TASK [Download the Figure_To_Pdf.py script] *************************************************************************************************************************************************************************
changed: [pub-omero.openmicroscopy.org]

PLAY RECAP **********************************************************************************************************************************************************************************************************
pub-omero.openmicroscopy.org : ok=146  changed=10   unreachable=0    failed=0    skipped=70   rescued=0    ignored=0   
````
</details>

<details>
 <summary>ome-demoserver</summary>

  ````diff
TASK [ome.postgresql : postgres | postgresql config file] ************************************************************
--- before
+++ after
@@ -1,4 +1,4 @@
 {
-    "mode": "0654",
+    "mode": "0640",
     "path": "/var/lib/pgsql/10/data/postgresql.conf"
 }

changed: [sls-repo.openmicroscopy.org]

TASK [ome.postgresql : postgres | configure client authorisation] ****************************************************
--- before
+++ after
@@ -1,4 +1,4 @@
 {
-    "mode": "0654",
+    "mode": "0640",
     "path": "/var/lib/pgsql/10/data/pg_hba.conf"
 }

changed: [sls-repo.openmicroscopy.org]

TASK [ome.postgresql : postgres | start service] *********************************************************************
ok: [sls-repo.openmicroscopy.org]

TASK [ome.postgresql : postgres | create users] **********************************************************************
changed: [sls-repo.openmicroscopy.org] => (item={'user': 'omero', 'password': '****', 'databases': ['omero']})
TASK [ome.omero_server : omero server | configuration 00-omero-server.omero] *****************************************
--- before: /opt/omero/server/config/00-omero-server.omero
+++ after: /Users/sbesson/.ansible/tmp/ansible-local-48635yaz7659h/tmpwymns4mc/00-omero-server-omero.j2
@@ -5,7 +5,7 @@
 config set omero.db.host localhost
 config set omero.db.user omero
 config set omero.db.name omero
-config set omero.db.pass omero
+config set omero.db.pass hQ7qT9gL3kR2mR6a
 
 config set omero.data.dir /OMERO
 
@@ -35,3 +35,4 @@
 config set -- omero.security.trustStore /etc/pki/java/cacerts
 config set -- omero.security.trustStorePassword changeit
 
+certificates -v

changed: [sls-repo.openmicroscopy.org]
TASK [ome.omero_server : omero server | systemd service] *************************************************************
--- before: /etc/systemd/system/omero-server.service
+++ after: /Users/sbesson/.ansible/tmp/ansible-local-48635yaz7659h/tmp515pj3of/systemd-system-omero-server-service.j2
@@ -8,7 +8,6 @@
 After=postgresql-9.6.service
 After=postgresql-10.service
 After=postgresql-11.service
-Requires=network.service
 After=network.service
 
 [Service]

changed: [sls-repo.openmicroscopy.org]
[WARNING]: flush_handlers task does not support when conditional


RUNNING HANDLER [ome.postgresql : restart postgresql] ****************************************************************
changed: [sls-repo.openmicroscopy.org]

RUNNING HANDLER [ome.omero_common : reload systemd] ******************************************************************
changed: [sls-repo.openmicroscopy.org]

RUNNING HANDLER [ome.omero_server : omero-server rewrite omero-server configuration] *********************************
changed: [sls-repo.openmicroscopy.org]

RUNNING HANDLER [ome.omero_server : omero-server restart omero-server] ***********************************************
changed: [sls-repo.openmicroscopy.org]
````
</details>

The `learning` and `ome-dundeeomero` playbooks have also been executed in check-mode and the changed tasks are identical to the ones above. NB: the `ome-dundeeomero` fails due to the system_monitor_agent version incompatibility and this will need to be dealt independent of this PR.

### Testing

Minimal testing should be performed on `ome-training-3` and `pub-omero` ideally:
- login using the default 4064 port (`omero login -C root@localhost:4064`) as well as Websockets (`omero login -C root@wss://localhost:4066`)
- test a minimal import

## Production deployment

Once validated, proposing to schedule the deployment of this PR against all training and demo servers on Thursday/Friday. 

- [ ] ome-training-1
- [ ] ome-training-2
- [x] ome-training-3
- [ ] ome-training-4
- [ ] pub-omero
- [ ] ome-demo
- [x] sls-repo

The remaining servers will need to be handled separately anyways as the playbook will require a server restart.