### PR TITLE
Add new sub-playbook to manage training IDR datasets

### DIFF
--- a/omero/training-server/idr_data.yml
+++ b/omero/training-server/idr_data.yml
@@ -1,0 +1,22 @@
+---
+- hosts: ome-outreach
+  tasks:
+    - name: Clone study metadata
+      become: yes
+      git:
+        dest: /uod/idr/metadata/{{ item }}
+        repo: https://github.com/IDR/{{ item }}
+        update: yes
+      loop: "{{ studies | default([]) }}"
+
+    - name: Check existence of study data directory
+      stat:
+        path: /uod/idr/filesets/{{ item }}
+      register: stat_results
+      loop: "{{ studies | default([]) }}"
+
+    - name: Fail if data directory is missing
+      fail:
+        msg: "/uod/idr/filesets/{{ item.item }} does not exist"
+      when: not item.stat.exists
+      loop: "{{ stat_results.results }}"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -408,3 +408,4 @@
     external_nic: "{{ ansible_default_ipv4.interface }}"
 
 - include: letsencrypt.yml
+- include: idr_data.yml


### PR DESCRIPTION
Fixes https://github.com/ome/prod-playbooks/issues/312

This PR adds a sub-playbook to the training playbook to manage the metadata and binary data of IDR studies used by the OME training servers.

For each study defined in the `studies` variables (empty by default)
- clones the associated metadata repository under `/uod/idr/metadata`
- checks the existence of an associated fileset directory under `/uod/idr/filesets` and fails if non-existent