### PR TITLE
SLS OMERO.server: playbook and concurrent import fixes

### DIFF
--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -194,6 +194,7 @@
 
     omero_server_config_set_production:
       omero.db.poolsize: 60
+      omero.fs.repo.path: "%user%_%userId%/%thread%//%year%-%month%/%day%/%time%"
       omero.jvmcfg.percent.blitz: 50
       omero.jvmcfg.percent.indexer: 20
       omero.jvmcfg.percent.pixeldata: 20

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -39,11 +39,6 @@
         - mencoder # For the 'make movie' script
 
   roles:
-    # Now OME are using RHEL without Spacewalk, the current best-method of
-    # checking `is server SLS` is checking for the SLS nameservers.
-    - role: ome.system_monitor_agent
-      when: "'10.1.255.216' in ansible_dns.nameservers"
-
     # Disk Layout - PostgreSQL | data dir
     - role: ome.lvm_partition
       tags: lvm
@@ -164,45 +159,6 @@
       notify:
         - restart nginx
 
-    - name: Check_MK postgres plugin | check for plugin existence
-      tags: monitoring
-      stat:
-        path: "{{ check_mk_agent_plugin_path }}/mk_postgres"
-      register: check_mk_postgres_plugin_st
-
-    - name: Check_MK postgres plugin | activate the plugin
-      tags: monitoring
-      become: yes
-      command: cp "{{ check_mk_agent_plugin_path }}/mk_postgres" /usr/share/check-mk-agent/plugins/ creates=/usr/share/check-mk-agent/plugins/mk_postgres
-      when: check_mk_postgres_plugin_st.stat.exists
-
-    - name: Check_MK logwatch plugin | check for plugin existence
-      tags: monitoring
-      stat:
-        path: "{{ check_mk_agent_plugin_path }}/mk_logwatch"
-      register: check_mk_logwatch_plugin_st
-
-    - name: Check_MK logwatch plugin | activate the plugin
-      tags: monitoring
-      become: yes
-      command: cp "{{ check_mk_agent_plugin_path }}/mk_logwatch" /usr/share/check-mk-agent/plugins/ creates=/usr/share/check-mk-agent/plugins/mk_logwatch
-      when: check_mk_logwatch_plugin_st.stat.exists
-
-    - name: Check_MK logwatch plugin | check for default config file
-      tags: monitoring
-      stat:
-        path: "{{ check_mk_agent_config_example_path }}/logwatch.cfg"
-      register: check_mk_logwatch_plugin_conf_st
-
-    - name: Check_MK logwatch plugin | copy the default config
-      tags: monitoring
-      become: yes
-      command: >-
-        cp "{{ check_mk_agent_config_example_path }}/logwatch.cfg"
-        "{{ check_mk_agent_config_path }}/logwatch.cfg"
-        creates="{{ check_mk_agent_config_path }}/logwatch.cfg"
-      when: check_mk_logwatch_plugin_conf_st.stat.exists
-
     - name: PostgreSQL Nightly Backups | Remove old cron job
       become: yes
       file:
@@ -230,11 +186,6 @@
   vars:
     # For https://github.com/openmicroscopy/ansible-role-java, which is a dependency.
     java_jdk_install: True
-
-    # Check_MK (system monitoring) paths
-    check_mk_agent_plugin_path: /usr/share/check-mk-agent/available-plugins
-    check_mk_agent_config_example_path: /usr/share/check_mk/agents/cfg_examples
-    check_mk_agent_config_path: /etc/check-mk-agent
 
     nginx_version: 1.18.0
     postgresql_version: "11"


### PR DESCRIPTION
Proposed changes for deployment

- [x] removes `check_mk` from the playbook - discovered during https://github.com/ome/prod-playbooks/pull/313 the package installed by the role is no longer available in the package repositories and prevents the playbook from executing
- [x] set `omero.fs.repo.path` to support concurrent imports at the same millisecond. Reported by a user of the system