### PR TITLE
2021-SV3 deployment (part 1)

### DIFF
--- a/nightshade-webclients.yml
+++ b/nightshade-webclients.yml
@@ -102,10 +102,10 @@
         (omero_web_config_set_for_host | default({})))
       }}
 
-    omero_web_release: "{{ omero_web_release_override | default('5.9.2') }}"
-    omero_figure_release: "{{ omero_figure_release_override | default('4.4.0') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.11.0') }}"
+    omero_figure_release: "{{ omero_figure_release_override | default('4.4.1') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"
-    omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.10.2') }}"
+    omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.11.1') }}"
     omero_parade_release: "{{ omero_parade_release_override | default('0.2.1') }}"
     omero_webtagging_autotag_release: "{{ omero_webtagging_autotag_release_override | default('3.1.0') }}"
     omero_webtagging_tagsearch_release: "{{ omero_webtagging_tagsearch_release_override | default('3.1.0') }}"

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -311,17 +311,17 @@
 
   vars:
     django_cors_headers_release: "{{ django_cors_headers_release_override | default('2.5.3') }}"
-    omero_figure_release: "{{ omero_figure_release_override | default('4.4.0') }}"
-    omero_figure_script_release: "{{ omero_figure_script_release_override | default('v4.4.0') }}"
+    omero_figure_release: "{{ omero_figure_release_override | default('4.4.1') }}"
+    omero_figure_script_release: "{{ omero_figure_script_release_override | default('v4.4.1') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"
-    omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.10.2') }}"
+    omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.11.1') }}"
     omero_parade_release: "{{ omero_parade_release_override | default('0.2.1') }}"
     omero_webtagging_autotag_release: "{{ omero_webtagging_autotag_release_override | default('3.1.0') }}"
     omero_webtagging_tagsearch_release: "{{ omero_webtagging_tagsearch_release_override | default('3.1.0') }}"
     omero_signup_release: "{{ omero_signup_release_override | default('0.3.0') }}"
 
     omero_server_release: "{{ omero_server_release_override | default('5.6.3') }}"
-    omero_web_release: "{{ omero_web_release_override | default('5.9.2') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.11.0') }}"
     # For https://github.com/openmicroscopy/ansible-role-java, which is a dependency.
     java_jdk_install: True
 

--- a/sls-gallery.yml
+++ b/sls-gallery.yml
@@ -155,6 +155,6 @@
 
   vars:
     omero_server_release: 5.6.3
-    omero_web_release: 5.9.1
+    omero_web_release: 5.11.0
     omero_web_apps_release:
-      omero_iviewer: 0.10.2
+      omero_iviewer: 0.11.1


### PR DESCRIPTION
Following the [latest security announcement](https://www.openmicroscopy.org/2021/10/14/omero-web-5.11.0.html), this upgrades the playbook of some of our production systems to deploy the latest version of OMERO.web, OMERO.figure and OMERO.iviewer.


Deployed on 
- [x] pub-omero
- [x] ome-demo
- [x] ns-web
- [x] ns-web-pub
- [x] sls-gallery

The  remaining UoD OMERO systems (training & learning) will be upgraded separately
