### PR TITLE
Bump OMERO.web to 5.12.0 across all production UoD playbooks

### DIFF
--- a/learning.yml
+++ b/learning.yml
@@ -162,7 +162,7 @@
 
   vars:
     omero_server_release: 5.6.3
-    omero_web_release: 5.11.0
+    omero_web_release: 5.12.0
     omero_web_apps_release:
       omero_gallery: 3.3.2
       omero_iviewer: 0.11.1

--- a/nightshade-webclients.yml
+++ b/nightshade-webclients.yml
@@ -102,7 +102,7 @@
         (omero_web_config_set_for_host | default({})))
       }}
 
-    omero_web_release: "{{ omero_web_release_override | default('5.11.0') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.12.0') }}"
     omero_figure_release: "{{ omero_figure_release_override | default('4.4.1') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"
     omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.11.1') }}"

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -321,7 +321,7 @@
     omero_signup_release: "{{ omero_signup_release_override | default('0.3.0') }}"
 
     omero_server_release: "{{ omero_server_release_override | default('5.6.3') }}"
-    omero_web_release: "{{ omero_web_release_override | default('5.11.0') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.12.0') }}"
     # For https://github.com/openmicroscopy/ansible-role-java, which is a dependency.
     java_jdk_install: True
 

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -333,7 +333,7 @@
     omero_server_datadir_managedrepo_mode: u=rwX,g=srwX,o=rX,+t
     omero_server_datadir_chown: False
     omero_server_release: "{{ omero_server_release_override | default('5.6.3') }}"
-    omero_web_release: "{{ omero_web_release_override | default('5.11.0') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.12.0') }}"
     omero_figure_release: "{{ omero_figure_release_override | default('4.4.1') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"
     omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.11.1') }}"

--- a/sls-gallery.yml
+++ b/sls-gallery.yml
@@ -155,6 +155,6 @@
 
   vars:
     omero_server_release: 5.6.3
-    omero_web_release: 5.11.0
+    omero_web_release: 5.12.0
     omero_web_apps_release:
       omero_iviewer: 0.11.1


### PR DESCRIPTION
Deployment checklist

- [x] learning.openmicroscopy.org
- [x] sls-repo.openmicroscopy.org
- [x] nightshade.openmicroscopy.org / omero.lifesci.dundee.ac.uk
- [x] demo.openmicroscopy.org / pub-omero.openmicroscopy.org
- [ ] ome-training-3.openmicroscopy.org / ome-training-4.openmicroscopy.org
- [ ] outreach.openmicroscopy.org
- [ ] workshop.openmicroscopy.org