### PR TITLE
Bump ome.omero_prometheus_exporter to 0.3.3

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -44,7 +44,7 @@
   version: 1.2.0
 
 - name: ome.omero_prometheus_exporter
-  version: 0.3.2
+  version: 0.3.3
 
 - name: ome.omero_server
   version: 4.0.2


### PR DESCRIPTION
Include `omero_prometheus_tools` bug fix as well as the cleanup of former Python 2-based deployment. 

- [x] ome-training-4.openmicroscopy.org
- [x] ome-dundeeomero.openmicroscopy.org
- [x] ome-demoserver.openmicroscopy.org
- [x] outreach.openmicroscopy.org
- [x] workshop.openmicroscopy.org
- [x] ome-training-3.openmicroscopy.org
- [x] pub-omero.openmicroscopy.org

