### PR TITLE
www: remove proxying of OME schemas

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -32,8 +32,7 @@
   version: 2.1.1
 
 - name: ome.nginx_proxy
-  src: https://github.com/ome/ansible-role-nginx-proxy/archive/37390104dd4119805c0c9e984bf207c98fb12f1a.tar.gz
-  version: 1.16.0
+  version: 1.15.2
 
 - src: ome.nfs_mount
   version: 1.3.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -31,8 +31,9 @@
 - src: ome.nginx
   version: 2.1.1
 
-- src: ome.nginx_proxy
-  version: 1.15.1
+- name: ome.nginx_proxy
+  src: https://github.com/ome/ansible-role-nginx-proxy/archive/37390104dd4119805c0c9e984bf207c98fb12f1a.tar.gz
+  version: 1.16.0
 
 - src: ome.nfs_mount
   version: 1.3.0

--- a/www/www-deploy.yml
+++ b/www/www-deploy.yml
@@ -32,9 +32,6 @@
         server: https://www-legacy.openmicroscopy.org/qa2
       - location: /static
         server: https://www-legacy.openmicroscopy.org
-      # Proxy locations for OME Data Model schemas
-      - location: /schema_doc
-        server: https://www-legacy.openmicroscopy.org
 
     nginx_proxy_redirect_map_locations:
     # TODO: change to 301 when we're happy
@@ -282,6 +279,9 @@
     - location: "/"
       root: "/var/www/www.openmicroscopy.org/html"
       index: index.html
+
+    - location: "^~ /Schemas/Documentation/Generated/"
+      alias: /var/www/schemas_documentation/
 
     # Static copy of old phpBB forums: treat query params as part of filename
     - location: "~ ^/community/style.php.*"

--- a/www/www-deploy.yml
+++ b/www/www-deploy.yml
@@ -51,6 +51,8 @@
       code: 302
     - location: "~ ^/(XMLschemas)($|/)"
       code: 302
+    - location: "~ ^/(Schemas/Samples)($|/)"
+      code: 302
 
     nginx_proxy_redirect_map:
     # by default redirect to the 404 page
@@ -272,8 +274,30 @@
     - match: "~/info/(.*)?$"
       dest: /site-map
 
+    # Legacy XMLschemas endpoint
     - match: "~/XMLschemas/(?<link>.*[^/])?$"
       dest: /Schemas/$link
+
+    # Legacy schemas samples
+    - match:
+        "~/Schemas/Samples/2013-06/bioformats-artificial/\
+        multi-channel-4D-series.ome.tif.zip"
+      dest:
+        "https://downloads.openmicroscopy.org/images/OME-TIFF/\
+        2013-06/bioformats-artificial/multi-channel-4D-series.ome.tif"
+    - match: "~/Schemas/Samples/2015-01/set-1-meta-companion"
+      dest:
+        https://downloads.openmicroscopy.org/images/OME-TIFF/2015-01/companion/
+    - match:
+        "~/Schemas/Samples/2015-01/bioformats-artificial/\
+        multi-channel-time-series.ome.tif.zip"
+      dest:
+        "https://downloads.openmicroscopy.org/images/OME-TIFF/\
+        2015-01/bioformats-artificial/multi-channel-time-series.ome.tif"
+    - match: "~/Schemas/Samples/(?<link>.*)?$"
+      dest: https://downloads.openmicroscopy.org/images/OME-TIFF/$link
+    - match: "~/Schemas/Samples"
+      dest: https://downloads.openmicroscopy.org/images/
 
     nginx_proxy_direct_locations:
     - location: "/"

--- a/www/www-deploy.yml
+++ b/www/www-deploy.yml
@@ -33,10 +33,6 @@
       - location: /static
         server: https://www-legacy.openmicroscopy.org
       # Proxy locations for OME Data Model schemas
-      - location: /Schemas
-        server: https://www-legacy.openmicroscopy.org/Schemas
-      - location: /XMLschemas
-        server: https://www-legacy.openmicroscopy.org/XMLschemas
       - location: /schema_doc
         server: https://www-legacy.openmicroscopy.org
 
@@ -55,6 +51,8 @@
     - location: "~ ^/(info)($|/)"
       code: 302
     - location: "~ ^/(forums)($|/)"
+      code: 302
+    - location: "~ ^/(XMLschemas)($|/)"
       code: 302
 
     nginx_proxy_redirect_map:
@@ -276,6 +274,9 @@
       dest: https://www.intelligent-imaging.com/technical-answers
     - match: "~/info/(.*)?$"
       dest: /site-map
+
+    - match: "~/XMLschemas/(?<link>.*[^/])?$"
+      dest: /Schemas/$link
 
     nginx_proxy_direct_locations:
     - location: "/"

--- a/www/www-static.yml
+++ b/www/www-static.yml
@@ -8,6 +8,11 @@
       path: "{{ phpbbforum_style_file }}"
     register: _phpbbforum_style_file_st
 
+  - name: Check if schemas_documentation already unzipped
+    stat:
+      path: "{{ schemas_doc_file }}"
+    register: _schemas_doc_file_st
+
   roles:
   - role: ome.deploy_archive
     become: yes
@@ -16,6 +21,14 @@
     deploy_archive_sha256: e9d7a7eefbacf42ddbdf92b201584913cb6d94ec331750f811232b2e91aa5b40
     # This file is patched later so only unzip if it doesn't exist
     when: not _phpbbforum_style_file_st.stat.exists
+
+  - role: ome.deploy_archive
+    become: yes
+    deploy_archive_dest_dir: /var/www
+    deploy_archive_src_url: https://downloads.openmicroscopy.org/web-archive/schemas_documentation-20211213.tar.gz
+    deploy_archive_sha256: 27cc5def458112a2e259484906f2bc8c0e0e2bd0a728b0a478302537d67117ec
+    # This file is patched later so only unzip if it doesn't exist
+    when: not _schemas_doc_file_st.stat.exists
 
   tasks:
   - name: install deployment script
@@ -58,3 +71,4 @@
 
   vars:
     phpbbforum_style_file: "/var/www/phpbbforum/www.openmicroscopy.org/community/style.php?id=7&lang=en"
+    schemas_doc_file: "/var/www/schemas_documentation/OME-2016-06/ome.html"


### PR DESCRIPTION
This was driven by the issue in the www/www-legacy proxying following the migration. As a general rule, this removes a non-necessary dependency.

Changes;
- removes the proxying of `/Schemas` as these are included as part of the static website artifact (see https://github.com/ome/www.openmicroscopy.org/pull/420)
- removes the proxying of `/XMLschemas`, replaced by a location redirect
- removes the proxying of `/Schemas/Documentation/Generated`, replaces by a similar strategy as the old phpbb forum i.e. downloading a static bundle containing the oXygen documentation and using `location/alias` to serve the documentation
- add redirects for legacy `/Schemas/Samples` endpoint

Also depends on https://github.com/ome/ansible-role-nginx-proxy/pull/33 to fix the broken deployment following recent nginx distribution changes.

This PR has been deployed on `ome-www-dev` for testing. Below are a few URLs to review:

- https://ome-www-dev.openmicroscopy.org/Schemas/
- https://ome-www-dev.openmicroscopy.org/Schemas/OME/
- https://ome-www-dev.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd
- https://ome-www-dev.openmicroscopy.org/XMLschemas/OME/FC/ome.xsd
- https://ome-www-dev.openmicroscopy.org/Schemas/Documentation/Generated/OME-2016-06/ome.html
- https://ome-www-dev.openmicroscopy.org/Schemas/Samples/  - should redirect to all sample images (should it be OME-TIFF?)
- https://ome-www-dev.openmicroscopy.org/Schemas/Samples/2013-06/ - should redirect to 2013-06 OME-TIFF folder
- https://ome-www-dev.openmicroscopy.org/Schemas/Samples/2016-06/tubhiswt-2D.zip - should redirect to 2016-06 zip
- https://ome-www-dev.openmicroscopy.org/Schemas/Samples/2013-06/bioformats-artificial/multi-channel-4D-series.ome.tif.zip
- https://ome-www-dev.openmicroscopy.org/Schemas/Samples/2015-01/set-1-meta-companion
- https://ome-www-dev.openmicroscopy.org/Schemas/Samples/2015-01/bioformats-artificial/multi-channel-time-series.ome.tif.zip