### PR TITLE
Django upgrade

### DIFF
--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -387,7 +387,7 @@
     omero_server_datadir_managedrepo_mode: u=rwX,g=srwX,o=rX,+t
     omero_server_datadir_chown: False
     omero_server_release: "{{ omero_server_release_override | default('5.6.3') }}"
-    omero_web_release: "{{ omero_web_release_override | default('5.14.0.rc1') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.14.0') }}"
     omero_figure_release: "{{ omero_figure_release_override | default('4.4.3') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"
     omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.11.3') }}"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -82,19 +82,19 @@
            - "omero_iviewer"
            - "omero_figure"
            - "omero_fpbioimage"
-           - "omero_webtagging_autotag"
-           - "omero_webtagging_tagsearch"
+           #- "omero_webtagging_autotag"
+           #- "omero_webtagging_tagsearch"
            - "omero_parade"
            - "omero_mapr"
         omero.web.ui.center_plugins:
-          - ["Auto Tag", "omero_webtagging_autotag/auto_tag_init.js.html", "auto_tag_panel"]
+          #- ["Auto Tag", "omero_webtagging_autotag/auto_tag_init.js.html", "auto_tag_panel"]
           - ["Parade", "omero_parade/init.js.html", "omero_parade"]
         omero.web.ui.top_links:
           - ["Data", "webindex", {"title": "Browse Data via Projects, Tags etc"}]
           - ["History", "history", {"title": "History"}]
           - ["Help", "https://help.openmicroscopy.org/", {"title": "Open OMERO user guide in a new tab", "target": "new"}]
           - ["Figure", "figure_index", {"title": "Open Figure in new tab", "target": "_blank"}]
-          - ["Tag Search", "tagsearch"]
+          #- ["Tag Search", "tagsearch"]
           - ["Genes", {"query_string": {"experimenter": -1}, "viewname": "maprindex_gene"}, {"title": "Find Gene annotations"}]
           - ["Key-Value", {"viewname": "maprindex_keyvalue"}, {"title": "Search for manually-added Key-Value pairs"}]
         omero.web.open_with:

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -387,12 +387,12 @@
     omero_server_datadir_managedrepo_mode: u=rwX,g=srwX,o=rX,+t
     omero_server_datadir_chown: False
     omero_server_release: "{{ omero_server_release_override | default('5.6.3') }}"
-    omero_web_release: "{{ omero_web_release_override | default('5.12.0') }}"
-    omero_figure_release: "{{ omero_figure_release_override | default('4.4.1') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.14.0.rc1') }}"
+    omero_figure_release: "{{ omero_figure_release_override | default('4.4.3') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"
-    omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.11.1') }}"
-    omero_mapr_release: "{{ omero_mapr_release_override | default('0.4.1') }}"
-    omero_parade_release: "{{ omero_parade_release_override | default('0.2.1') }}"
+    omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.11.3') }}"
+    omero_mapr_release: "{{ omero_mapr_release_override | default('0.5rc1') }}"
+    omero_parade_release: "{{ omero_parade_release_override | default('0.2.3') }}"
 
     # The omero_web_apps_* vars are used by the ome.omero_web role under
     # Python 3 otherwise ignored
@@ -402,12 +402,12 @@
       - "omero-iviewer=={{ omero_iviewer_release }}"
       - "omero-mapr=={{ omero_mapr_release }}"
       - "omero-parade=={{ omero_parade_release }}"
-      - "omero-webtagging-autotag=={{ omero_webtagging_autotag_release }}"
-      - "omero-webtagging-tagsearch=={{ omero_webtagging_tagsearch_release }}"
+      #- "omero-webtagging-autotag=={{ omero_webtagging_autotag_release }}"
+      #- "omero-webtagging-tagsearch=={{ omero_webtagging_tagsearch_release }}"
 
     ome_training_scripts_release: "{{ ome_training_scripts_release_override | default('0.2.0') }}"
-    omero_webtagging_autotag_release: "{{ omero_webtagging_autotag_release_override | default('3.1.0') }}"
-    omero_webtagging_tagsearch_release: "{{ omero_webtagging_tagsearch_release_override | default('3.1.0') }}"
+    #omero_webtagging_autotag_release: "{{ omero_webtagging_autotag_release_override | default('3.1.0') }}"
+    #omero_webtagging_tagsearch_release: "{{ omero_webtagging_tagsearch_release_override | default('3.1.0') }}"
     omero_cli_duplicate_release: "{{ omero_cli_duplicate_release_override | default('0.4.0') }}"
     omero_metadata_release: "{{ omero_metadata_release_overrride | default('0.8.0') }}"
     omero_cli_render_release: "{{ omero_cli_render_release_override | default('0.7.0') }}"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -406,8 +406,8 @@
       #- "omero-webtagging-tagsearch=={{ omero_webtagging_tagsearch_release }}"
 
     ome_training_scripts_release: "{{ ome_training_scripts_release_override | default('0.2.0') }}"
-    #omero_webtagging_autotag_release: "{{ omero_webtagging_autotag_release_override | default('3.1.0') }}"
-    #omero_webtagging_tagsearch_release: "{{ omero_webtagging_tagsearch_release_override | default('3.1.0') }}"
+    omero_webtagging_autotag_release: "{{ omero_webtagging_autotag_release_override | default('3.1.0') }}"
+    omero_webtagging_tagsearch_release: "{{ omero_webtagging_tagsearch_release_override | default('3.1.0') }}"
     omero_cli_duplicate_release: "{{ omero_cli_duplicate_release_override | default('0.4.0') }}"
     omero_metadata_release: "{{ omero_metadata_release_overrride | default('0.8.0') }}"
     omero_cli_render_release: "{{ omero_cli_render_release_override | default('0.7.0') }}"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -82,19 +82,19 @@
            - "omero_iviewer"
            - "omero_figure"
            - "omero_fpbioimage"
-           #- "omero_webtagging_autotag"
-           #- "omero_webtagging_tagsearch"
+           - "omero_webtagging_autotag"
+           - "omero_webtagging_tagsearch"
            - "omero_parade"
            - "omero_mapr"
         omero.web.ui.center_plugins:
-          #- ["Auto Tag", "omero_webtagging_autotag/auto_tag_init.js.html", "auto_tag_panel"]
+          - ["Auto Tag", "omero_webtagging_autotag/auto_tag_init.js.html", "auto_tag_panel"]
           - ["Parade", "omero_parade/init.js.html", "omero_parade"]
         omero.web.ui.top_links:
           - ["Data", "webindex", {"title": "Browse Data via Projects, Tags etc"}]
           - ["History", "history", {"title": "History"}]
           - ["Help", "https://help.openmicroscopy.org/", {"title": "Open OMERO user guide in a new tab", "target": "new"}]
           - ["Figure", "figure_index", {"title": "Open Figure in new tab", "target": "_blank"}]
-          #- ["Tag Search", "tagsearch"]
+          - ["Tag Search", "tagsearch"]
           - ["Genes", {"query_string": {"experimenter": -1}, "viewname": "maprindex_gene"}, {"title": "Find Gene annotations"}]
           - ["Key-Value", {"viewname": "maprindex_keyvalue"}, {"title": "Search for manually-added Key-Value pairs"}]
         omero.web.open_with:
@@ -402,12 +402,12 @@
       - "omero-iviewer=={{ omero_iviewer_release }}"
       - "omero-mapr=={{ omero_mapr_release }}"
       - "omero-parade=={{ omero_parade_release }}"
-      #- "omero-webtagging-autotag=={{ omero_webtagging_autotag_release }}"
-      #- "omero-webtagging-tagsearch=={{ omero_webtagging_tagsearch_release }}"
+      - "omero-webtagging-autotag=={{ omero_webtagging_autotag_release }}"
+      - "omero-webtagging-tagsearch=={{ omero_webtagging_tagsearch_release }}"
 
     ome_training_scripts_release: "{{ ome_training_scripts_release_override | default('0.2.0') }}"
-    omero_webtagging_autotag_release: "{{ omero_webtagging_autotag_release_override | default('3.1.0') }}"
-    omero_webtagging_tagsearch_release: "{{ omero_webtagging_tagsearch_release_override | default('3.1.0') }}"
+    omero_webtagging_autotag_release: "{{ omero_webtagging_autotag_release_override | default('3.2.0') }}"
+    omero_webtagging_tagsearch_release: "{{ omero_webtagging_tagsearch_release_override | default('3.2.0') }}"
     omero_cli_duplicate_release: "{{ omero_cli_duplicate_release_override | default('0.4.0') }}"
     omero_metadata_release: "{{ omero_metadata_release_overrride | default('0.8.0') }}"
     omero_cli_render_release: "{{ omero_cli_render_release_override | default('0.7.0') }}"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -391,7 +391,7 @@
     omero_figure_release: "{{ omero_figure_release_override | default('4.4.3') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"
     omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.11.3') }}"
-    omero_mapr_release: "{{ omero_mapr_release_override | default('0.5rc1') }}"
+    omero_mapr_release: "{{ omero_mapr_release_override | default('0.5.0') }}"
     omero_parade_release: "{{ omero_parade_release_override | default('0.2.3') }}"
 
     # The omero_web_apps_* vars are used by the ome.omero_web role under


### PR DESCRIPTION
cc @sbesson 

the changes are on top of https://github.com/ome/prod-playbooks/pull/334

Deployed successfully on ome-training-3

Possibly there is a change in ``mapr`` in between ?
This here is a status from couple of days ago, with RC on mapr.