### PR TITLE
learning: bump OMERO.web components to the released versions using Django 3.2

### DIFF
--- a/omero/learning.yml
+++ b/omero/learning.yml
@@ -162,8 +162,8 @@
 
   vars:
     omero_server_release: 5.6.3
-    omero_web_release: 5.12.0
+    omero_web_release: 5.14.0
     omero_web_apps_release:
-      omero_gallery: 3.3.2
-      omero_iviewer: 0.11.1
-      omero_virtual_microscope: 1.1.0
+      omero_gallery: 3.4.2
+      omero_iviewer: 0.11.3
+      omero_virtual_microscope: 1.2.0

--- a/omero/learning.yml
+++ b/omero/learning.yml
@@ -115,7 +115,7 @@
         - omero-iviewer=={{ omero_web_apps_release.omero_iviewer }}
         - omero-virtual-microscope=={{ omero_web_apps_release.omero_virtual_microscope }}
       omero_web_python_addons:
-        - "django-redis<4.9"
+        - "django-redis==5.0.0"
 
   tasks:
     - name: find OMERO.server log configuration


### PR DESCRIPTION
Fixes #339 

To be deployed on Thursday April 7th