### PR TITLE
Upgrade server to 5.6.4

### DIFF
--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -386,7 +386,7 @@
     omero_server_system_managedrepo_group: managed_repo_group
     omero_server_datadir_managedrepo_mode: u=rwX,g=srwX,o=rX,+t
     omero_server_datadir_chown: False
-    omero_server_release: "{{ omero_server_release_override | default('5.6.3') }}"
+    omero_server_release: "{{ omero_server_release_override | default('5.6.4') }}"
     omero_web_release: "{{ omero_web_release_override | default('5.14.0') }}"
     omero_figure_release: "{{ omero_figure_release_override | default('4.4.3') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"


### PR DESCRIPTION
@sbesson @jburel @dominikl 


Trying to upgrade of omero server to 5.6.4.

```
ansible-playbook -i /Users/pwalczysko/Work/management_tools/ansible/inventory/staging-hosts -l ome-training-3.openmicroscopy.org --become omero/training-server/playbook.yml --diff
....
TASK [ome.omero_server : debug] ************************************************
ok: [ome-training-3.openmicroscopy.org] => {
    "msg": "Upgrade needed: 5.6.3 -> 5.6.4"
}

```

But inside the ``ome-training-3`` I have

```
omero admin diagnostics

lib/server/omero-server.jar    jar	5.6.3	
```

any ideas ?