### PR TITLE
Add public user to web config

### DIFF
--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -77,7 +77,26 @@
 
     - role: ome.omero_web
       tags: ['web']
-      omero_web_config_set:
+        idr_omero_web_public_url_filters_webclient_exclude:
+          - action
+          - annotate_(file|tags|comment|rating|map)
+          - script_ui
+          - ome_tiff
+          - figure_script
+        idr_omero_web_public_url_filters:
+          - api/
+          - webadmin/myphoto/
+          - mapr/
+          - figure/
+          - iviewer/
+          - '$'
+          - gallery-api/
+          - gallery_settings/
+          - cell/
+          - tissue/
+          - webclient/(?!({{ idr_omero_web_public_url_filters_webclient_exclude | join('|') }}))
+          - webgateway/(?!(archived_files|download_as))
+        omero_web_config_set:
         omero.web.apps:
            - "omero_iviewer"
            - "omero_figure"
@@ -144,7 +163,7 @@
 
         omero.web.public.enabled: true
         omero.web.public.password: "{{ omero_web_public_password_override }}"
-        omero.web.public.url_filter: ^\/(api|iviewer|figure|webadmin\/myphoto\/|webclient\/(?!(script_ui|ome_tiff|figure_script|render_image_download|download_|ome_tiff_script|archived_files\/download|download_orig_metadata))|webgateway\/(?!(archived_files|download_as)))
+        omero.web.public.url_filter: "^/({{ idr_omero_web_public_url_filters | join('|') }})"
         omero.web.public.user: "{{ omero_web_public_user_override }}"
 
     - role: ome.iptables_raw

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -163,9 +163,9 @@
             }
 
         omero.web.public.enabled: true
-        omero.web.public.password: "{{ omero_web_public_password_override }}"
+        omero.web.public.password: "{{ omero_web_public_password_override | default('secret') }}"
         omero.web.public.url_filter: "^/({{ idr_omero_web_public_url_filters | join('|') }})"
-        omero.web.public.user: "{{ omero_web_public_user_override }}"
+        omero.web.public.user: "{{ omero_web_public_user_override | default('secret') }}"
 
     - role: ome.iptables_raw
 

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -142,6 +142,11 @@
               proxy_read_timeout 86400;
             }
 
+        omero.web.public.enabled: true
+        omero.web.public.password: "{{ omero_web_public_password_override }}"
+        omero.web.public.url_filter: ^/(webgateway/\w+|webclient/annotation/([0-9]+)/)
+        omero.web.public.user: "{{ omero_web_public_user_override }}"
+
     - role: ome.iptables_raw
 
     - role: ome.docker

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -50,26 +50,6 @@
         mode: 0644
       # Don't notify, nginx isn't installed yet
 
-  idr_omero_web_public_url_filters_webclient_exclude:
-    - action
-    - annotate_(file|tags|comment|rating|map)
-    - script_ui
-    - ome_tiff
-    - figure_script
-  idr_omero_web_public_url_filters:
-    - api/
-    - webadmin/myphoto/
-    - mapr/
-    - figure/
-    - iviewer/
-    - '$'
-    - gallery-api/
-    - gallery_settings/
-    - cell/
-    - tissue/
-    - webclient/(?!({{ idr_omero_web_public_url_filters_webclient_exclude | join('|') }}))
-    - webgateway/(?!(archived_files|download_as))
-
   roles:
 
     - role: ome.postgresql
@@ -97,6 +77,26 @@
 
     - role: ome.omero_web
       tags: ['web']
+      idr_omero_web_public_url_filters_webclient_exclude:
+        - action
+        - annotate_(file|tags|comment|rating|map)
+        - script_ui
+        - ome_tiff
+        - figure_script
+      idr_omero_web_public_url_filters:
+        - api/
+        - webadmin/myphoto/
+        - mapr/
+        - figure/
+        - iviewer/
+        - '$'
+        - gallery-api/
+        - gallery_settings/
+        - cell/
+        - tissue/
+        - webclient/(?!({{ idr_omero_web_public_url_filters_webclient_exclude | join('|') }}))
+        - webgateway/(?!(archived_files|download_as))
+
       omero_web_config_set:
         omero.web.apps:
            - "omero_iviewer"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -144,7 +144,7 @@
 
         omero.web.public.enabled: true
         omero.web.public.password: "{{ omero_web_public_password_override }}"
-        omero.web.public.url_filter: ^/(webgateway/\w+|webclient/annotation/([0-9]+)/)
+        omero.web.public.url_filter: ^\/(api|iviewer|figure|webadmin\/myphoto\/|webclient\/(?!(script_ui|ome_tiff|figure_script|render_image_download|download_|ome_tiff_script|archived_files\/download|download_orig_metadata))|webgateway\/(?!(archived_files|download_as)))
         omero.web.public.user: "{{ omero_web_public_user_override }}"
 
     - role: ome.iptables_raw

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -97,7 +97,7 @@
 
     - role: ome.omero_web
       tags: ['web']
-        omero_web_config_set:
+      omero_web_config_set:
         omero.web.apps:
            - "omero_iviewer"
            - "omero_figure"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -50,6 +50,26 @@
         mode: 0644
       # Don't notify, nginx isn't installed yet
 
+  idr_omero_web_public_url_filters_webclient_exclude:
+    - action
+    - annotate_(file|tags|comment|rating|map)
+    - script_ui
+    - ome_tiff
+    - figure_script
+  idr_omero_web_public_url_filters:
+    - api/
+    - webadmin/myphoto/
+    - mapr/
+    - figure/
+    - iviewer/
+    - '$'
+    - gallery-api/
+    - gallery_settings/
+    - cell/
+    - tissue/
+    - webclient/(?!({{ idr_omero_web_public_url_filters_webclient_exclude | join('|') }}))
+    - webgateway/(?!(archived_files|download_as))
+
   roles:
 
     - role: ome.postgresql
@@ -77,25 +97,6 @@
 
     - role: ome.omero_web
       tags: ['web']
-        idr_omero_web_public_url_filters_webclient_exclude:
-          - action
-          - annotate_(file|tags|comment|rating|map)
-          - script_ui
-          - ome_tiff
-          - figure_script
-        idr_omero_web_public_url_filters:
-          - api/
-          - webadmin/myphoto/
-          - mapr/
-          - figure/
-          - iviewer/
-          - '$'
-          - gallery-api/
-          - gallery_settings/
-          - cell/
-          - tissue/
-          - webclient/(?!({{ idr_omero_web_public_url_filters_webclient_exclude | join('|') }}))
-          - webgateway/(?!(archived_files|download_as))
         omero_web_config_set:
         omero.web.apps:
            - "omero_iviewer"


### PR DESCRIPTION
In exploration of adding of public user to outreach server via omero web config.
Does not work very well atm. When a new public user is created, and a new public group, the Dataset inside that group is not publicly visible, e.g. https://ome-training-4.openmicroscopy.org/webclient/?show=dataset-5405
Not sure where the mistake is.

cc @jburel @sbesson 

