### PR TITLE
Bump omero_web_release to 5.14.1 everywhere

### DIFF
--- a/omero/learning.yml
+++ b/omero/learning.yml
@@ -162,7 +162,7 @@
 
   vars:
     omero_server_release: 5.6.3
-    omero_web_release: 5.14.0
+    omero_web_release: 5.14.1
     omero_web_apps_release:
       omero_gallery: 3.4.2
       omero_iviewer: 0.11.3

--- a/omero/nightshade-webclients.yml
+++ b/omero/nightshade-webclients.yml
@@ -102,7 +102,7 @@
         (omero_web_config_set_for_host | default({})))
       }}
 
-    omero_web_release: "{{ omero_web_release_override | default('5.14.0') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.14.1') }}"
     omero_figure_release: "{{ omero_figure_release_override | default('4.4.3') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"
     omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.11.3') }}"

--- a/omero/ome-demoserver.yml
+++ b/omero/ome-demoserver.yml
@@ -319,7 +319,7 @@
     omero_signup_release: "{{ omero_signup_release_override | default('0.3.2') }}"
 
     omero_server_release: "{{ omero_server_release_override | default('5.6.4') }}"
-    omero_web_release: "{{ omero_web_release_override | default('5.14.0') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.14.1') }}"
     # For https://github.com/openmicroscopy/ansible-role-java, which is a dependency.
     java_jdk_install: True
 

--- a/omero/sls-gallery.yml
+++ b/omero/sls-gallery.yml
@@ -141,6 +141,6 @@
 
   vars:
     omero_server_release: 5.6.3
-    omero_web_release: 5.14.0
+    omero_web_release: 5.14.1
     omero_web_apps_release:
       omero_iviewer: 0.11.3

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -387,7 +387,7 @@
     omero_server_datadir_managedrepo_mode: u=rwX,g=srwX,o=rX,+t
     omero_server_datadir_chown: False
     omero_server_release: "{{ omero_server_release_override | default('5.6.4') }}"
-    omero_web_release: "{{ omero_web_release_override | default('5.14.1') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.14.0') }}"
     omero_figure_release: "{{ omero_figure_release_override | default('4.4.3') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"
     omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.11.3') }}"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -387,7 +387,7 @@
     omero_server_datadir_managedrepo_mode: u=rwX,g=srwX,o=rX,+t
     omero_server_datadir_chown: False
     omero_server_release: "{{ omero_server_release_override | default('5.6.4') }}"
-    omero_web_release: "{{ omero_web_release_override | default('5.14.0') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.14.1') }}"
     omero_figure_release: "{{ omero_figure_release_override | default('4.4.3') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"
     omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.11.3') }}"


### PR DESCRIPTION
This bumps omero-web on nightshade, demo-server, training-server and sls-gallery.

