### PR TITLE
Upgrade web and download figure publish scripts

### DIFF
--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -203,6 +203,26 @@
         group: "omero-server"
         force: yes
 
+    - name: Download the Dataset_Images_To_New_Figure.py script
+      become: yes
+      get_url:
+        url: https://raw.githubusercontent.com/ome/omero-guide-figure/master/scripts/Dataset_Images_To_New_Figure.py
+        dest: /opt/omero/server/OMERO.server/lib/scripts/omero/figure_scripts/Dataset_Images_To_New_Figure.py
+        mode: 0755
+        owner: "omero-server"
+        group: "omero-server"
+        force: yes
+
+    - name: Download the Figure_Images_To_Dataset.py script
+      become: yes
+      get_url:
+        url: https://raw.githubusercontent.com/ome/omero-guide-figure/master/scripts/Figure_Images_To_Dataset.py
+        dest: /opt/omero/server/OMERO.server/lib/scripts/omero/figure_scripts/Figure_Images_To_Dataset.py
+        mode: 0755
+        owner: "omero-server"
+        group: "omero-server"
+        force: yes
+
     - name: Create a workshop_scripts directory
       become: yes
       file:
@@ -412,7 +432,7 @@
     omero_server_datadir_managedrepo_mode: u=rwX,g=srwX,o=rX,+t
     omero_server_datadir_chown: False
     omero_server_release: "{{ omero_server_release_override | default('5.6.4') }}"
-    omero_web_release: "{{ omero_web_release_override | default('5.14.0') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.14.1') }}"
     omero_figure_release: "{{ omero_figure_release_override | default('4.4.3') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"
     omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.11.3') }}"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -206,7 +206,7 @@
     - name: Download the Dataset_Images_To_New_Figure.py script
       become: yes
       get_url:
-        url: https://raw.githubusercontent.com/ome/omero-guide-figure/master/scripts/Dataset_Images_To_New_Figure.py
+        url: https://raw.githubusercontent.com/ome/omero-guide-figure/f45f733a16852ae8b3c52ec93aef480d26b8e9f9/scripts/Dataset_Images_To_New_Figure.py
         dest: /opt/omero/server/OMERO.server/lib/scripts/omero/figure_scripts/Dataset_Images_To_New_Figure.py
         mode: 0755
         owner: "omero-server"
@@ -216,7 +216,7 @@
     - name: Download the Figure_Images_To_Dataset.py script
       become: yes
       get_url:
-        url: https://raw.githubusercontent.com/ome/omero-guide-figure/master/scripts/Figure_Images_To_Dataset.py
+        url: https://raw.githubusercontent.com/ome/omero-guide-figure/f45f733a16852ae8b3c52ec93aef480d26b8e9f9/scripts/Figure_Images_To_Dataset.py
         dest: /opt/omero/server/OMERO.server/lib/scripts/omero/figure_scripts/Figure_Images_To_Dataset.py
         mode: 0755
         owner: "omero-server"


### PR DESCRIPTION
Successfully deployed on 

 - ome-training-4
 - outreach
 - workshop

but not on ome-training-3. This server is left out intentionally for https://github.com/ome/prod-playbooks/pull/349 testing