### PR TITLE
Upgrade OMERO.server on training-servers to 5.6.5

### DIFF
--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -437,7 +437,7 @@
     omero_server_system_managedrepo_group: managed_repo_group
     omero_server_datadir_managedrepo_mode: u=rwX,g=srwX,o=rX,+t
     omero_server_datadir_chown: False
-    omero_server_release: "{{ omero_server_release_override | default('5.6.4') }}"
+    omero_server_release: "{{ omero_server_release_override | default('5.6.5') }}"
     omero_web_release: "{{ omero_web_release_override | default('5.14.1') }}"
     omero_figure_release: "{{ omero_figure_release_override | default('4.4.3') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"


### PR DESCRIPTION
Upgrading the training servers to OMERO.server 5.6.5.

Successfully applied to all 4 training servers, see below.
cc @sbesson 


```
2022-07-04 14:25:52,489 184        [      main] INFO          ome.formats.importer.ImportConfig - OMERO.blitz Version: 5.5.12
2022-07-04 14:25:52,505 200        [      main] INFO          ome.formats.importer.ImportConfig - Bioformats version: 6.10.0 revision: f8b46c2458c43cffdf5bc67cc4bf9dfc6e93167b date: 31 May 2022
2022-07-04 14:25:52,546 241        [      main] INFO   formats.importer.cli.CommandLineImporter - Setting transfer to ln_s
2022-07-04 14:25:52,550 245        [      main] INFO   formats.importer.cli.CommandLineImporter - Log levels -- Bio-Formats: ERROR OMERO.importer: INFO
2022-07-04 14:25:52,888 583        [      main] INFO      ome.formats.importer.ImportCandidates - Depth: 4 Metadata Level: MINIMUM
2022-07-04 14:25:53,004 699        [      main] INFO      ome.formats.importer.ImportCandidates - 1 file(s) parsed into 1 group(s) with 1 call(s) to setId in 99ms. (116ms total) [0 unknowns]
2022-07-04 14:25:53,046 741        [      main] INFO       ome.formats.OMEROMetadataStoreClient - Attempting initial SSL connection to localhost:4064
2022-07-04 14:25:53,528 1223       [      main] INFO       ome.formats.OMEROMetadataStoreClient - Insecure connection requested, falling back
2022-07-04 14:25:53,824 1519       [      main] INFO       ome.formats.OMEROMetadataStoreClient - Pinging session every 300s.
2022-07-04 14:25:53,831 1526       [      main] INFO       ome.formats.OMEROMetadataStoreClient - Server: 5.6.5
```