### PR TITLE
Omeropy 5.12.0 web 5.15

### DIFF
--- a/omero/learning.yml
+++ b/omero/learning.yml
@@ -169,7 +169,7 @@
   vars:
     postgresql_version: "13"
     omero_server_release: 5.6.5
-    omero_web_release: 5.14.1
+    omero_web_release: 5.15.0
     omero_web_apps_release:
       omero_gallery: 3.4.2
       omero_iviewer: 0.11.3

--- a/omero/learning.yml
+++ b/omero/learning.yml
@@ -115,6 +115,7 @@
         - omero-virtual-microscope=={{ omero_web_apps_release.omero_virtual_microscope }}
       omero_web_python_addons:
         - "django-redis==5.0.0"
+        - "omero-py>={{ omero_py_release }}"
 
     - role: ome.postgresql_backup
       postgresql_backup_compress: true
@@ -170,6 +171,7 @@
     postgresql_version: "13"
     omero_server_release: 5.6.5
     omero_web_release: 5.15.0
+    omero_py_release: "{{ omero_py_release_override | default('5.12.0') }}"
     omero_web_apps_release:
       omero_gallery: 3.4.2
       omero_iviewer: 0.11.3

--- a/omero/nightshade-webclients.yml
+++ b/omero/nightshade-webclients.yml
@@ -21,6 +21,8 @@
     # OMERO.web configuration in host_vars in different repository
     - role: ome.omero_web
       omero_web_systemd_limit_nofile: 16384
+      omero_web_python_addons:
+        - "omero-py>={{ omero_py_release }}"
 
     # Now OME are using RHEL without Spacewalk, the current best-method of
     # checking `is server deployed in Dundee/SLS` is checking for the SLS nameservers.
@@ -103,6 +105,7 @@
       }}
 
     omero_web_release: "{{ omero_web_release_override | default('5.15.0') }}"
+    omero_py_release: "{{ omero_py_release_override | default('5.12.0') }}"
     omero_figure_release: "{{ omero_figure_release_override | default('5.0.0') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"
     omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.11.3') }}"

--- a/omero/nightshade-webclients.yml
+++ b/omero/nightshade-webclients.yml
@@ -102,7 +102,7 @@
         (omero_web_config_set_for_host | default({})))
       }}
 
-    omero_web_release: "{{ omero_web_release_override | default('5.14.1') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.15.0') }}"
     omero_figure_release: "{{ omero_figure_release_override | default('5.0.0') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"
     omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.11.3') }}"

--- a/omero/ome-demoserver.yml
+++ b/omero/ome-demoserver.yml
@@ -123,6 +123,7 @@
         - "omero-iviewer=={{ omero_iviewer_release }}"
         - "omero-parade=={{ omero_parade_release }}"
         - "omero-signup=={{ omero_signup_release }}"
+        - "omero-py>={{ omero_py_release }}"
 
     - role: ome.omero_user
       no_log: true
@@ -320,6 +321,7 @@
 
     omero_server_release: "{{ omero_server_release_override | default('5.6.5') }}"
     omero_web_release: "{{ omero_web_release_override | default('5.15.0') }}"
+    omero_py_release: "{{ omero_py_release_override | default('5.12.0') }}"
     # For https://github.com/openmicroscopy/ansible-role-java, which is a dependency.
     java_jdk_install: True
 

--- a/omero/ome-demoserver.yml
+++ b/omero/ome-demoserver.yml
@@ -319,7 +319,7 @@
     omero_signup_release: "{{ omero_signup_release_override | default('0.3.2') }}"
 
     omero_server_release: "{{ omero_server_release_override | default('5.6.5') }}"
-    omero_web_release: "{{ omero_web_release_override | default('5.14.1') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.15.0') }}"
     # For https://github.com/openmicroscopy/ansible-role-java, which is a dependency.
     java_jdk_install: True
 

--- a/omero/sls-gallery.yml
+++ b/omero/sls-gallery.yml
@@ -147,6 +147,6 @@
   vars:
     postgresql_version: "13"
     omero_server_release: 5.6.3
-    omero_web_release: 5.14.1
+    omero_web_release: 5.15.0
     omero_web_apps_release:
       omero_iviewer: 0.11.3

--- a/omero/sls-gallery.yml
+++ b/omero/sls-gallery.yml
@@ -110,6 +110,7 @@
         - omero-iviewer=={{ omero_web_apps_release.omero_iviewer }}
       omero_web_python_addons:
         - "django-redis==5.0.0"
+        - "omero-py>={{ omero_py_release }}"
 
   tasks:
     - name: find OMERO.server log configuration
@@ -150,3 +151,4 @@
     omero_web_release: 5.15.0
     omero_web_apps_release:
       omero_iviewer: 0.11.3
+    omero_py_release: "{{ omero_py_release_override | default('5.12.0') }}"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -102,6 +102,8 @@
         - tissue/
         - webclient/(?!({{ idr_omero_web_public_url_filters_webclient_exclude | join('|') }}))
         - webgateway/(?!(archived_files|download_as))
+      omero_web_python_addons:
+        - "omero-py>={{ omero_py_release }}"
 
       omero_web_config_set:
         omero.web.apps:
@@ -444,6 +446,7 @@
     omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.11.3') }}"
     omero_mapr_release: "{{ omero_mapr_release_override | default('0.5.0') }}"
     omero_parade_release: "{{ omero_parade_release_override | default('0.2.3') }}"
+    omero_py_release: "{{ omero_py_release_override | default('5.12.0') }}"
 
     # The omero_web_apps_* vars are used by the ome.omero_web role under
     # Python 3 otherwise ignored

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -440,7 +440,7 @@
     omero_server_datadir_managedrepo_mode: u=rwX,g=srwX,o=rX,+t
     omero_server_datadir_chown: False
     omero_server_release: "{{ omero_server_release_override | default('5.6.5') }}"
-    omero_web_release: "{{ omero_web_release_override | default('5.14.1') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.15.0') }}"
     omero_figure_release: "{{ omero_figure_release_override | default('5.0.0') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"
     omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.11.3') }}"


### PR DESCRIPTION
Updating recent releases of omero-web and omero-py (which needs to use `omero_web_python_addons`)

cc @sbesson @pwalczysko 