### PR TITLE
Disable pixelservice on demo server

### DIFF
--- a/omero/ome-demoserver.yml
+++ b/omero/ome-demoserver.yml
@@ -374,7 +374,7 @@
       omero.mail.from: "{{ omero_server_mail_from }}"
       omero.mail.host: "{{ omero_server_mail_host }}"
       omero.new_user_group: "My Data"
-      omero.pixeldata.cron: ""
+      omero.server.nodedescriptors: "master:Blitz-0,Indexer-0,Processor-0,Storm,Tables-0"
       omero.search.batch: 100
       omero.throttling.method_time.error: 60000
 

--- a/omero/ome-demoserver.yml
+++ b/omero/ome-demoserver.yml
@@ -374,6 +374,7 @@
       omero.mail.from: "{{ omero_server_mail_from }}"
       omero.mail.host: "{{ omero_server_mail_host }}"
       omero.new_user_group: "My Data"
+      omero.pixeldata.cron: ""
       omero.search.batch: 100
       omero.throttling.method_time.error: 60000
 


### PR DESCRIPTION
As discussed, disabling pixels on demo, see discussion in https://openmicroscopy.slack.com/archives/C0K5ME1EW/p1668597336544119

cc @sbesson @jburel 


This was run agains demoserver successfully


```
omero admin diagnostics

================================================================================
OMERO Diagnostics (admin) 5.12.0
================================================================================
        
Commands:   java -version                  1.8.0     (/usr/bin/java)
Commands:   python -V                      3.6.8     (/opt/omero/server/venv3/bin/python -- 2 others)
Commands:   icegridnode --version          3.6.5     (/usr/bin/icegridnode)
Commands:   icegridadmin --version         3.6.5     (/usr/bin/icegridadmin)
Commands:   psql --version                 11.14     (/usr/bin/psql)
Commands:   openssl version                1.0.2     (/usr/bin/openssl)

Server:     icegridnode                    running
Server:     Blitz-0                        active (pid = 32471, enabled)
Server:     Indexer-0                      active (pid = 32485, enabled)
Server:     OMERO.Glacier2                 active (pid = 32489, enabled)
Server:     OMERO.IceStorm                 active (pid = 32504, enabled)
Server:     Processor-0                    active (pid = 32499, enabled)
Server:     Tables-0                       active (pid = 32510, ena
```