### PR TITLE
Upgrade 5.6.6 and other bumps

### DIFF
--- a/omero/learning.yml
+++ b/omero/learning.yml
@@ -45,6 +45,8 @@
       lvm_shrink: False
 
     - role: ome.omero_server
+      omero_server_python_addons:
+        - "omero-py>={{ omero_py_release }}"
       omero_server_config_set:
         omero.client.ui.menu.dropdown.colleagues.enabled: False
         omero.client.ui.menu.dropdown.everyone.label: "All courses"
@@ -169,10 +171,10 @@
 
   vars:
     postgresql_version: "13"
-    omero_server_release: 5.6.5
-    omero_web_release: 5.15.0
-    omero_py_release: "{{ omero_py_release_override | default('5.12.0') }}"
+    omero_server_release: 5.6.6
+    omero_web_release: 5.16.0
+    omero_py_release: "{{ omero_py_release_override | default('5.13.1') }}"
     omero_web_apps_release:
       omero_gallery: 3.4.2
-      omero_iviewer: 0.11.3
+      omero_iviewer: 0.12.0
       omero_virtual_microscope: 1.2.0

--- a/omero/nightshade-webclients.yml
+++ b/omero/nightshade-webclients.yml
@@ -104,11 +104,11 @@
         (omero_web_config_set_for_host | default({})))
       }}
 
-    omero_web_release: "{{ omero_web_release_override | default('5.15.0') }}"
-    omero_py_release: "{{ omero_py_release_override | default('5.12.0') }}"
-    omero_figure_release: "{{ omero_figure_release_override | default('5.0.0') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.16.0') }}"
+    omero_py_release: "{{ omero_py_release_override | default('5.13.1') }}"
+    omero_figure_release: "{{ omero_figure_release_override | default('5.1.0') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"
-    omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.11.3') }}"
+    omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.12.0') }}"
     omero_parade_release: "{{ omero_parade_release_override | default('0.2.3') }}"
     omero_webtagging_autotag_release: "{{ omero_webtagging_autotag_release_override | default('3.2.0') }}"
     omero_webtagging_tagsearch_release: "{{ omero_webtagging_tagsearch_release_override | default('3.2.0') }}"

--- a/omero/ome-demoserver.yml
+++ b/omero/ome-demoserver.yml
@@ -310,18 +310,18 @@
         force: yes
 
   vars:
-    omero_figure_release: "{{ omero_figure_release_override | default('5.0.0') }}"
-    omero_figure_script_release: "{{ omero_figure_script_release_override | default('v5.0.0') }}"
+    omero_figure_release: "{{ omero_figure_release_override | default('5.1.0') }}"
+    omero_figure_script_release: "{{ omero_figure_script_release_override | default('v5.1.0') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"
-    omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.11.3') }}"
+    omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.12.0') }}"
     omero_parade_release: "{{ omero_parade_release_override | default('0.2.3') }}"
     omero_webtagging_autotag_release: "{{ omero_webtagging_autotag_release_override | default('3.2.0') }}"
     omero_webtagging_tagsearch_release: "{{ omero_webtagging_tagsearch_release_override | default('3.2.0') }}"
     omero_signup_release: "{{ omero_signup_release_override | default('0.3.2') }}"
 
-    omero_server_release: "{{ omero_server_release_override | default('5.6.5') }}"
-    omero_web_release: "{{ omero_web_release_override | default('5.15.0') }}"
-    omero_py_release: "{{ omero_py_release_override | default('5.12.0') }}"
+    omero_server_release: "{{ omero_server_release_override | default('5.6.6') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.16.0') }}"
+    omero_py_release: "{{ omero_py_release_override | default('5.13.1') }}"
     # For https://github.com/openmicroscopy/ansible-role-java, which is a dependency.
     java_jdk_install: True
 
@@ -386,6 +386,7 @@
       # For OMERO.figure script
       - "reportlab<3.6"
       - markdown
+      - "omero-py>={{ omero_py_release }}"
 
     omero_server_selfsigned_certificates: True
 

--- a/omero/ome-dundeeomero.yml
+++ b/omero/ome-dundeeomero.yml
@@ -209,6 +209,7 @@
     postgresql_version: "11"
     filesystem: "xfs"
     omero_figure_release: "{{ omero_figure_release_override | default('5.1.0') }}"
+    omero_py_release: "{{ omero_py_release_override | default('5.13.1') }}"
 
     omero_server_config_set_production:
       omero.db.poolsize: 60

--- a/omero/ome-dundeeomero.yml
+++ b/omero/ome-dundeeomero.yml
@@ -239,6 +239,7 @@
       # For OMERO.figure script
       - "reportlab<3.6"
       - markdown
+      - "omero-py>={{ omero_py_release }}"
 
     # Workaround lack of restriction on temp file sizes
     # https://github.com/ome/omero-web/issues/118

--- a/omero/ome-dundeeomero.yml
+++ b/omero/ome-dundeeomero.yml
@@ -74,7 +74,7 @@
     # Note - had to have these set to `install-mock` to progress role
     # installation before changing config to restored DB from other system.
     - role: ome.omero_server
-      omero_server_release: 5.6.5
+      omero_server_release: 5.6.6
       omero_server_datadir_manage: "{{ molecule_test | default(False) }}"
       omero_server_systemd_limit_nofile: 16384
       omero_server_systemd_after: >-
@@ -208,7 +208,7 @@
     nginx_version: 1.18.0
     postgresql_version: "11"
     filesystem: "xfs"
-    omero_figure_release: "{{ omero_figure_release_override | default('5.0.0') }}"
+    omero_figure_release: "{{ omero_figure_release_override | default('5.1.0') }}"
 
     omero_server_config_set_production:
       omero.db.poolsize: 60

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -75,6 +75,7 @@
         - "omero-cli-duplicate=={{ omero_cli_duplicate_release }}"
         - "omero-cli-render=={{ omero_cli_render_release }}"
         - "omero-metadata=={{ omero_metadata_release }}"
+        - "omero-py>={{ omero_py_release }}"
         - "reportlab<3.6"
         - markdown
         - scipy
@@ -439,14 +440,14 @@
     omero_server_system_managedrepo_group: managed_repo_group
     omero_server_datadir_managedrepo_mode: u=rwX,g=srwX,o=rX,+t
     omero_server_datadir_chown: False
-    omero_server_release: "{{ omero_server_release_override | default('5.6.5') }}"
-    omero_web_release: "{{ omero_web_release_override | default('5.15.0') }}"
-    omero_figure_release: "{{ omero_figure_release_override | default('5.0.0') }}"
+    omero_server_release: "{{ omero_server_release_override | default('5.6.6') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.16.0') }}"
+    omero_figure_release: "{{ omero_figure_release_override | default('5.1.0') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"
-    omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.11.3') }}"
+    omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.12.0') }}"
     omero_mapr_release: "{{ omero_mapr_release_override | default('0.5.0') }}"
     omero_parade_release: "{{ omero_parade_release_override | default('0.2.3') }}"
-    omero_py_release: "{{ omero_py_release_override | default('5.12.0') }}"
+    omero_py_release: "{{ omero_py_release_override | default('5.13.1') }}"
 
     # The omero_web_apps_* vars are used by the ome.omero_web role under
     # Python 3 otherwise ignored


### PR DESCRIPTION
Upgrades:

1. server 5.6.6
2. web 5.16.0
3. figure
4. iviewer
5. omero-py 5.13.1

Further:
- adding logic to each playbook to upgrade to latest omero-py when server is upgraded - please check this one @sbesson 

This was deployed on 

- [x] ome-training-4
- [x] ome-training-3
- [x] outreach
- [x] workshop
- [x] demo
- [x] learning (in the time 4 - 6 January 2023 - clarified with the appropriate person)
- [x] send ns users email
- [x] nightshade (in the time 5 January 2023 at 12.00 - 12.30)

cc @jburel 
