### PR TITLE
Upgrade and cleanup

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -20,7 +20,7 @@ jobs:
     name: Test
     needs:
       - list-scenarios
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       # Keep running so we can see if other tests pass
       fail-fast: false

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -20,7 +20,7 @@ jobs:
     name: Test
     needs:
       - list-scenarios
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       # Keep running so we can see if other tests pass
       fail-fast: false

--- a/omero/learning.yml
+++ b/omero/learning.yml
@@ -171,7 +171,7 @@
 
   vars:
     postgresql_version: "13"
-    omero_server_release: 5.6.6
+    omero_server_release: 5.6.7
     omero_web_release: 5.16.0
     omero_py_release: "{{ omero_py_release_override | default('5.13.1') }}"
     omero_web_apps_release:

--- a/omero/learning.yml
+++ b/omero/learning.yml
@@ -172,7 +172,7 @@
   vars:
     postgresql_version: "13"
     omero_server_release: 5.6.7
-    omero_web_release: 5.16.0
+    omero_web_release: 5.20.0
     omero_py_release: "{{ omero_py_release_override | default('5.13.1') }}"
     omero_web_apps_release:
       omero_gallery: 3.4.2

--- a/omero/nightshade-webclients.yml
+++ b/omero/nightshade-webclients.yml
@@ -104,7 +104,7 @@
         (omero_web_config_set_for_host | default({})))
       }}
 
-    omero_web_release: "{{ omero_web_release_override | default('5.16.0') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.20.0') }}"
     omero_py_release: "{{ omero_py_release_override | default('5.13.1') }}"
     omero_figure_release: "{{ omero_figure_release_override | default('5.1.0') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"

--- a/omero/ome-demoserver.yml
+++ b/omero/ome-demoserver.yml
@@ -382,7 +382,7 @@
       - "omero-cli-duplicate=={{ omero_cli_duplicate_release }}"
       - "omero-cli-render=={{ omero_cli_render_release }}"
       - "omero-metadata=={{ omero_metadata_release }}"
-      - "omero-demo-cleanup==git+https://github.com/ome/omero-demo-cleanup"
+      - "omero-demo-cleanup==0.2.0"
       # For OMERO.figure script
       - "reportlab<3.6"
       - markdown

--- a/omero/ome-demoserver.yml
+++ b/omero/ome-demoserver.yml
@@ -319,7 +319,7 @@
     omero_webtagging_tagsearch_release: "{{ omero_webtagging_tagsearch_release_override | default('3.2.0') }}"
     omero_signup_release: "{{ omero_signup_release_override | default('0.3.2') }}"
 
-    omero_server_release: "{{ omero_server_release_override | default('5.6.6') }}"
+    omero_server_release: "{{ omero_server_release_override | default('5.6.7') }}"
     omero_web_release: "{{ omero_web_release_override | default('5.16.0') }}"
     omero_py_release: "{{ omero_py_release_override | default('5.13.1') }}"
     # For https://github.com/openmicroscopy/ansible-role-java, which is a dependency.

--- a/omero/ome-demoserver.yml
+++ b/omero/ome-demoserver.yml
@@ -382,7 +382,7 @@
       - "omero-cli-duplicate=={{ omero_cli_duplicate_release }}"
       - "omero-cli-render=={{ omero_cli_render_release }}"
       - "omero-metadata=={{ omero_metadata_release }}"
-      - "omero-demo-cleanup==0.1.0"
+      - "omero-demo-cleanup==git+https://github.com/ome/omero-demo-cleanup"
       # For OMERO.figure script
       - "reportlab<3.6"
       - markdown

--- a/omero/ome-demoserver.yml
+++ b/omero/ome-demoserver.yml
@@ -320,7 +320,7 @@
     omero_signup_release: "{{ omero_signup_release_override | default('0.3.2') }}"
 
     omero_server_release: "{{ omero_server_release_override | default('5.6.7') }}"
-    omero_web_release: "{{ omero_web_release_override | default('5.16.0') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.20.0') }}"
     omero_py_release: "{{ omero_py_release_override | default('5.13.1') }}"
     # For https://github.com/openmicroscopy/ansible-role-java, which is a dependency.
     java_jdk_install: True

--- a/omero/ome-dundeeomero.yml
+++ b/omero/ome-dundeeomero.yml
@@ -74,7 +74,7 @@
     # Note - had to have these set to `install-mock` to progress role
     # installation before changing config to restored DB from other system.
     - role: ome.omero_server
-      omero_server_release: 5.6.6
+      omero_server_release: 5.6.7
       omero_server_datadir_manage: "{{ molecule_test | default(False) }}"
       omero_server_systemd_limit_nofile: 16384
       omero_server_systemd_after: >-

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -440,7 +440,7 @@
     omero_server_system_managedrepo_group: managed_repo_group
     omero_server_datadir_managedrepo_mode: u=rwX,g=srwX,o=rX,+t
     omero_server_datadir_chown: False
-    omero_server_release: "{{ omero_server_release_override | default('5.6.6') }}"
+    omero_server_release: "{{ omero_server_release_override | default('5.6.7') }}"
     omero_web_release: "{{ omero_web_release_override | default('5.16.0') }}"
     omero_figure_release: "{{ omero_figure_release_override | default('5.1.0') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -441,7 +441,7 @@
     omero_server_datadir_managedrepo_mode: u=rwX,g=srwX,o=rX,+t
     omero_server_datadir_chown: False
     omero_server_release: "{{ omero_server_release_override | default('5.6.7') }}"
-    omero_web_release: "{{ omero_web_release_override | default('5.16.0') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.20.0') }}"
     omero_figure_release: "{{ omero_figure_release_override | default('5.1.0') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"
     omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.12.0') }}"

--- a/requirements.yml
+++ b/requirements.yml
@@ -44,7 +44,7 @@
   version: 1.2.0
 
 - name: ome.omero_prometheus_exporter
-  version: 0.3.3
+  version: 0.3.6
 
 - name: ome.omero_server
   version: 4.0.2


### PR DESCRIPTION
1. A suggestion to upgrade the server to 5.6.7
2. A suggestion to add the install of the ``omero-demo-cleanup`` script from the master branch of the repo to have the script available on the demo server with the new changes

cc @sbesson @jburel 