### PR TITLE
Upgrade demo cleanup script

### DIFF
--- a/omero/ome-demoserver.yml
+++ b/omero/ome-demoserver.yml
@@ -422,7 +422,7 @@
       - "omero-cli-duplicate=={{ omero_cli_duplicate_release }}"
       - "omero-cli-render=={{ omero_cli_render_release }}"
       - "omero-metadata=={{ omero_metadata_release }}"
-      - "omero-demo-cleanup==0.1.0"
+      - "omero-demo-cleanup==0.2.1"
       # For OMERO.figure script
       - "reportlab<3.6"
       - markdown


### PR DESCRIPTION
Upgrading the cleanup script on the demo server.
Now, only the ``. /opt/omero/server/venv3/bin/activate`` is necessary to be able to run the script.

This PR is necessary as the venv established in the home folders of @dominikl @pwalczysko and @khaledk2 were taking too much space on the root partition of the server.

This was run successfully on demo server.


cc @sbesson @jburel 