### PR TITLE
Fix email

### DIFF
--- a/omero/learning.yml
+++ b/omero/learning.yml
@@ -192,8 +192,8 @@
 
   vars:
     postgresql_version: "13"
-    omero_server_release: 5.6.6
-    omero_web_release: 5.16.0
+    omero_server_release: 5.6.8
+    omero_web_release: 5.22.1
     omero_py_release: "{{ omero_py_release_override | default('5.13.1') }}"
     omero_web_apps_release:
       omero_gallery: 3.4.2

--- a/omero/nightshade-webclients.yml
+++ b/omero/nightshade-webclients.yml
@@ -109,14 +109,14 @@
         (omero_web_config_set_for_host | default({})))
       }}
 
-    omero_web_release: "{{ omero_web_release_override | default('5.16.0') }}"
-    omero_py_release: "{{ omero_py_release_override | default('5.13.1') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.22.1') }}"
+    omero_py_release: "{{ omero_py_release_override | default('5.15.0') }}"
     omero_figure_release: >-
-      {{ omero_figure_release_override | default('5.1.0') }}
+      {{ omero_figure_release_override | default('6.0.1') }}
     omero_fpbioimage_release: >-
-      {{ omero_fpbioimage_release_override | default('0.4.0') }}
+      {{ omero_fpbioimage_release_override | default('0.4.1') }}
     omero_iviewer_release: >-
-      {{ omero_iviewer_release_override | default('0.12.0') }}
+      {{ omero_iviewer_release_override | default('0.13.0') }}
     omero_parade_release: >-
       {{ omero_parade_release_override | default('0.2.3') }}
     omero_webtagging_autotag_release: >-

--- a/omero/ome-demoserver.yml
+++ b/omero/ome-demoserver.yml
@@ -334,7 +334,7 @@
     omero_figure_release: >-
       {{ omero_figure_release_override | default('6.0.1') }}
     omero_figure_script_release: >-
-      {{ omero_figure_script_release_override | default('v5.1.0') }}
+      {{ omero_figure_script_release_override | default('v6.0.1') }}
     omero_fpbioimage_release: >-
       {{ omero_fpbioimage_release_override | default('0.4.1') }}
     omero_iviewer_release: >-

--- a/omero/ome-demoserver.yml
+++ b/omero/ome-demoserver.yml
@@ -377,20 +377,16 @@
       password: {password}\n\n
       Use these login details as follows\n
       1. In your browser, go to demo.openmicroscopy.org and log in.\n
-      2. Download the OMERO.insight [1] desktop application to im
-      port your first data into OMERO.\n
-      3. Following the steps in the omero-guide [2], change the server ad
-      dress to\n
-      demo.openmicroscopy.org and connect\n
-      using the login details as above to import your data.\n
-      4. Use the walkthrough example [3] to get ideas about ho
-      w to start using OMERO.\n
+      2. Download the OMERO.insight [1] desktop application to import\n
+      your first data into OMERO.\n
+      3. Once OMERO.insight is started, following the steps in the\n omero-guide [1], change the server address to\n
+      demo.openmicroscopy.org\n
+      and connect using the login details as above to import your data.\n
+      4. Use the walkthrough example [1] to get further ideas about how
+      to start using OMERO.\n
       OME Team\n\n
-      [1] https://omero-guides.readthedocs.io/en/latest\
-      /upload/docs/import-desktop-client.html \n
-      [2] https://omero-guides.readthedocs.io/en/latest/upload/\
-      docs/import-desktop-client.html#step-by-step \n
-      [3] https://omero-guides.readthedocs.io/en/latest/example.html \n'
+      [1] In your browser, go to omero-guides.readthedocs.io/en/latest
+      and click on "OMERO walkthrough example" under "Getting started".
 
     postgresql_version: "11"
     filesystem: "xfs"

--- a/omero/ome-demoserver.yml
+++ b/omero/ome-demoserver.yml
@@ -386,7 +386,7 @@
       to start using OMERO.\n
       OME Team\n\n
       [1] In your browser, go to omero-guides.readthedocs.io/en/latest
-      and click on "OMERO walkthrough example" under "Getting started".
+      and click on OMERO walkthrough example under Getting started.'
 
     postgresql_version: "11"
     filesystem: "xfs"

--- a/omero/ome-demoserver.yml
+++ b/omero/ome-demoserver.yml
@@ -332,15 +332,15 @@
 
   vars:
     omero_figure_release: >-
-      {{ omero_figure_release_override | default('5.1.0') }}
+      {{ omero_figure_release_override | default('6.0.1') }}
     omero_figure_script_release: >-
       {{ omero_figure_script_release_override | default('v5.1.0') }}
     omero_fpbioimage_release: >-
-      {{ omero_fpbioimage_release_override | default('0.4.0') }}
+      {{ omero_fpbioimage_release_override | default('0.4.1') }}
     omero_iviewer_release: >-
-      {{ omero_iviewer_release_override | default('0.12.0') }}
+      {{ omero_iviewer_release_override | default('0.13.0') }}
     omero_parade_release: >-
-      {{ omero_parade_release_override | default('0.2.3') }}
+      {{ omero_parade_release_override | default('0.2.4') }}
     omero_webtagging_autotag_release: >-
       {{ omero_webtagging_autotag_release_override | default('3.2.0') }}
     omero_webtagging_tagsearch_release: >-
@@ -349,9 +349,9 @@
       {{ omero_signup_release_override | default('0.3.2') }}
 
     omero_server_release: >-
-      {{ omero_server_release_override | default('5.6.6') }}
-    omero_web_release: "{{ omero_web_release_override | default('5.16.0') }}"
-    omero_py_release: "{{ omero_py_release_override | default('5.13.1') }}"
+      {{ omero_server_release_override | default('5.6.8') }}
+    omero_web_release: "{{ omero_web_release_override | default('5.22.1') }}"
+    omero_py_release: "{{ omero_py_release_override | default('5.15.0') }}"
     # For https://github.com/openmicroscopy/ansible-role-java,
     # which is a dependency.
     java_jdk_install: true

--- a/omero/ome-dundeeomero.yml
+++ b/omero/ome-dundeeomero.yml
@@ -78,7 +78,7 @@
     # Note - had to have these set to `install-mock` to progress role
     # installation before changing config to restored DB from other system.
     - role: ome.omero_server
-      omero_server_release: 5.6.6
+      omero_server_release: 5.6.8
       omero_server_datadir_manage: "{{ molecule_test | default(False) }}"
       omero_server_systemd_limit_nofile: 16384
       omero_server_systemd_after: >-
@@ -229,8 +229,8 @@
     postgresql_version: "11"
     filesystem: "xfs"
     omero_figure_release: >-
-      {{ omero_figure_release_override | default('5.1.0') }}
-    omero_py_release: "{{ omero_py_release_override | default('5.13.1') }}"
+      {{ omero_figure_release_override | default('6.0.1') }}
+    omero_py_release: "{{ omero_py_release_override | default('5.15.0') }}"
 
     omero_server_config_set_production:
       omero.db.poolsize: 60

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -440,14 +440,14 @@
     omero_server_system_managedrepo_group: managed_repo_group
     omero_server_datadir_managedrepo_mode: u=rwX,g=srwX,o=rX,+t
     omero_server_datadir_chown: False
-    omero_server_release: "{{ omero_server_release_override | default('5.6.6') }}"
-    omero_web_release: "{{ omero_web_release_override | default('5.16.0') }}"
-    omero_figure_release: "{{ omero_figure_release_override | default('5.1.0') }}"
-    omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.0') }}"
-    omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.12.0') }}"
+    omero_server_release: "{{ omero_server_release_override | default('5.6.8') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.22.1') }}"
+    omero_figure_release: "{{ omero_figure_release_override | default('6.0.1') }}"
+    omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.4.1') }}"
+    omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.13.0') }}"
     omero_mapr_release: "{{ omero_mapr_release_override | default('0.5.0') }}"
-    omero_parade_release: "{{ omero_parade_release_override | default('0.2.3') }}"
-    omero_py_release: "{{ omero_py_release_override | default('5.13.1') }}"
+    omero_parade_release: "{{ omero_parade_release_override | default('0.2.4') }}"
+    omero_py_release: "{{ omero_py_release_override | default('5.15.0') }}"
 
     # The omero_web_apps_* vars are used by the ome.omero_web role under
     # Python 3 otherwise ignored

--- a/requirements.yml
+++ b/requirements.yml
@@ -44,7 +44,7 @@
   version: 1.2.0
 
 - name: ome.omero_prometheus_exporter
-  version: 0.3.3
+  version: 0.3.6
 
 - name: ome.omero_server
   version: 4.0.2


### PR DESCRIPTION
Following the discussion last week about the demo email, this is an attempt to 

1. remove typos introduced by formatting of the text inside YAML
2. remove links as they are possibly catched by spam filters, leave just one non-clickable link to walkthrough without https beginning
3. simplify the text

cc @jburel @sbesson 

Note: This is done on top of https://github.com/ome/prod-playbooks/pull/373 in order not to downgrade by accident.

The new email body looks as follows:
![Screenshot 2023-09-06 at 13 06 44](https://github.com/ome/prod-playbooks/assets/2478303/bbfd2e0d-6d66-409a-a609-be73d3701350)
