### PR TITLE
Add explanation how to skip ssl role

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ cd playbooks
 ansible-playbook --ask-become --become -i $PATH/TO/INVENTORY ome-demoserver.yml -l $YOUR-HOST-ADDRESS-OR-IP --diff
 ```
 
+Note: After first successful run of the playbook, it can be of advantage to skip some roles, e.g. the `ome.ssl_certificate` role. You can use the provided tag for it:
+
+```
+cd playbooks
+ansible-playbook --ask-become --become -i $PATH/TO/INVENTORY ome-demoserver.yml -l $YOUR-HOST-ADDRESS-OR-IP --diff --skip-tags "ssl"
+```
+
 
 
 Testing


### PR DESCRIPTION
It is useful to skip the ssl role in all but the first run of the playbook, as the ssl setup can vary very much and is often done manually.

Adding explanation about how to do it.

cc @jburel @khaledk2 