### PR TITLE
Python 3.12

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -8,7 +8,7 @@ on:
 jobs:
 
   list-scenarios:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.listscenarios.outputs.scenarios }}
     steps:
@@ -20,7 +20,7 @@ jobs:
     name: Test
     needs:
       - list-scenarios
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       # Keep running so we can see if other tests pass
       fail-fast: false
@@ -30,11 +30,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.12'
       - name: Install Ansible & Molecule
         run: |
-            pip install "ansible<8" "ansible-lint<6.13" flake8
-            pip install "molecule<5" "ansible-compat<4"
+            pip install "ansible" "ansible-lint" flake8
+            pip install "molecule" "ansible-compat"
             pip install molecule-plugins[docker] pytest-testinfra
       - name: Run molecule
         run: molecule test -s "${{ matrix.scenario }}"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ cd playbooks
 ansible-playbook --ask-become --become -i $PATH/TO/INVENTORY ome-demoserver.yml -l $YOUR-HOST-ADDRESS-OR-IP --diff
 ```
 
+Note: After first successful run of the playbook, it can be of advantage to skip some roles, e.g. the `ome.ssl_certificate` role. You can use the provided tag for it:
+
+```
+cd playbooks
+ansible-playbook --ask-become --become -i $PATH/TO/INVENTORY ome-demoserver.yml -l $YOUR-HOST-ADDRESS-OR-IP --diff --skip-tags "ssl"
+```
+
 
 
 Testing

--- a/playbooks/ome-demoserver.yml
+++ b/playbooks/ome-demoserver.yml
@@ -17,12 +17,12 @@
 
     - name: Check if server.key file exists
       stat: 
-        path: /etc/ssl/omero/server.key
+        path: "{{ icessl_default_dir_noself }}/server.key"
       register: serverkey_file
 
     - name: Set omero_certificates_key to server.key
       set_fact:
-        omero_certificates_key_override: server.key 
+        omero_certificates_key_override: server.key
       when: serverkey_file.stat.exists
 
   roles:

--- a/playbooks/ome-demoserver.yml
+++ b/playbooks/ome-demoserver.yml
@@ -185,29 +185,29 @@
         path: /etc/cron.daily/nightly-pg_dump-omero.sh
         state: absent
 
-    # - name: Create a figure scripts directory
-    #   become: true
-    #   ansible.builtin.file:
-    #     path: "{{ omero_server_basedir }}/OMERO.server/lib/\
-    #       scripts/omero/figure_scripts"
-    #     state: directory
-    #     mode: 0755
-    #     recurse: true
-    #     owner: "omero-server"
-    #     group: "omero-server"
+    - name: Create a figure scripts directory
+      become: true
+      ansible.builtin.file:
+        path: "{{ omero_server_basedir }}/OMERO.server/lib/\
+          scripts/omero/figure_scripts"
+        state: directory
+        mode: 0755
+        recurse: true
+        owner: "omero-server"
+        group: "omero-server"
 
-    # - name: Download the Figure_To_Pdf.py script
-    #   become: true
-    #   ansible.builtin.get_url:
-    #     url: "https://raw.githubusercontent.com/ome/omero-figure/\
-    #       {{ omero_figure_script_release }}/omero_figure/scripts/omero/\
-    #       figure_scripts/Figure_To_Pdf.py"
-    #     dest: "{{ omero_server_basedir }}/OMERO.server/lib/\
-    #       scripts/omero/figure_scripts/Figure_To_Pdf.py"
-    #     mode: 0755
-    #     owner: "omero-server"
-    #     group: "omero-server"
-    #     force: true
+    - name: Download the Figure_To_Pdf.py script
+      become: true
+      ansible.builtin.get_url:
+        url: "https://raw.githubusercontent.com/ome/omero-figure/\
+          {{ omero_figure_script_release }}/omero_figure/scripts/omero/\
+          figure_scripts/Figure_To_Pdf.py"
+        dest: "{{ omero_server_basedir }}/OMERO.server/lib/\
+          scripts/omero/figure_scripts/Figure_To_Pdf.py"
+        mode: 0755
+        owner: "omero-server"
+        group: "omero-server"
+        force: true
 
     - name: check if server.key file exists
       stat: 

--- a/playbooks/ome-demoserver.yml
+++ b/playbooks/ome-demoserver.yml
@@ -47,7 +47,7 @@
 
     - role: ome.nginx
 
-    - role: ome.omero_web
+    - role: omero_web
       # Defaults overridden in private configuration
       omero_web_systemd_limit_nofile: 16384
       omero_web_python_addons:

--- a/playbooks/ome-demoserver.yml
+++ b/playbooks/ome-demoserver.yml
@@ -29,6 +29,7 @@
 
     - role: ome.postgresql
       # no_log: true
+      tags: ssl
       postgresql_databases:
       - name: omero
         owner: omero-x
@@ -38,6 +39,7 @@
         databases: []
 
     - role: omero_server
+      tags: ssl
       # Defaults overridden in private configuration
       # omero_server_dbuser:
       # omero_server_dbpassword:
@@ -46,6 +48,7 @@
       omero_server_systemd_limit_nofile: 16384
 
     - role: ome.nginx
+      tags: ssl
 
     - role: omero_web
       # Defaults overridden in private configuration
@@ -227,7 +230,7 @@
     omero_certificates_owner:
     omero_certificates_key: >-
       {{ omero_certificates_key_override | default('') }}
-    nginx_version: 1.26.2
+    nginx_version: 1.29.1
     omero_figure_release: >-
       {{ omero_figure_release_override | default('7.2.1') }}
     omero_figure_script_release: >-

--- a/playbooks/ome-demoserver.yml
+++ b/playbooks/ome-demoserver.yml
@@ -223,7 +223,7 @@
     omero_server_selfsigned_certificates: true
     icessl_default_dir_self: "{{ omero_server_basedir }}/selfsigned"
     icessl_default_dir_noself: "/etc/ssl/omero"
-    icessl_default_dir: "{{ icessl_default_dir_self if omero_server_selfsigned_certificate else icessl_default_dir_noself }}"
+    icessl_default_dir: "{{ icessl_default_dir_self if omero_server_selfsigned_certificates else icessl_default_dir_noself }}"
     omero_certificates_owner:
     omero_certificates_key: >-
       {{ omero_certificates_key_override | default('') }}

--- a/playbooks/ome-demoserver.yml
+++ b/playbooks/ome-demoserver.yml
@@ -4,7 +4,7 @@
 # also pass `--extra-vars upgrade_webapps=True`
 
 - name: Demo server playbook
-  hosts: ome-demoservers-test
+  hosts: ome-demoservers
   pre_tasks:
     - name: Install open-vm-tools if system is a VMware vm
       become: true
@@ -39,7 +39,7 @@
         databases: []
 
     - role: omero_server
-      tags: ssl
+      # tags: ssl
       # Defaults overridden in private configuration
       # omero_server_dbuser:
       # omero_server_dbpassword:
@@ -48,7 +48,7 @@
       omero_server_systemd_limit_nofile: 16384
 
     - role: ome.nginx
-      tags: ssl
+      # tags: ssl
 
     - role: omero_web
       # Defaults overridden in private configuration
@@ -64,23 +64,23 @@
         - "omero-signup=={{ omero_signup_release }}"
         - "omero-py>={{ omero_py_release }}"
 
-    # - role: ome.omero_user
-    #   no_log: true
-    #   omero_user_system: omero-server
-    #   omero_user_admin_user: root
-    #   omero_user_admin_pass: "{{ omero_server_rootpassword }}"
-    #   omero_group_create:
-    #     - name: public
-    #       type: read-only
-    #     - name: "My Data"
-    #       type: private
-    #   omero_user_create:
-    #     - login: "{{ secret_omero_web_public_user | default('public') }}"
-    #       firstname: Public
-    #       lastname: User
-    #       password: >-
-    #         {{ secret_omero_web_public_password | default('public') }}
-    #       groups: "--group-name public"
+    - role: ome.omero_user
+      no_log: true
+      omero_user_system: omero-server
+      omero_user_admin_user: root
+      omero_user_admin_pass: "{{ omero_server_rootpassword }}"
+      omero_group_create:
+        - name: public
+          type: read-only
+        - name: "My Data"
+          type: private
+      omero_user_create:
+        - login: "{{ secret_omero_web_public_user | default('public') }}"
+          firstname: Public
+          lastname: User
+          password: >-
+            {{ secret_omero_web_public_password | default('public') }}
+          groups: "--group-name public"
 
     - role: ome.ssl_certificate
       tags: ssl

--- a/playbooks/ome-demoserver.yml
+++ b/playbooks/ome-demoserver.yml
@@ -45,7 +45,7 @@
       omero_server_dbname: omero
       omero_server_systemd_limit_nofile: 16384
 
-    - role: ome.nginx
+    - role: nginx
       # tags: ssl
 
     - role: omero_web

--- a/playbooks/ome-demoserver.yml
+++ b/playbooks/ome-demoserver.yml
@@ -185,31 +185,49 @@
         path: /etc/cron.daily/nightly-pg_dump-omero.sh
         state: absent
 
-    - name: Create a figure scripts directory
-      become: true
-      ansible.builtin.file:
-        path: "{{ omero_server_basedir }}/OMERO.server/lib/\
-          scripts/omero/figure_scripts"
-        state: directory
-        mode: 0755
-        recurse: true
-        owner: "omero-server"
-        group: "omero-server"
+    # - name: Create a figure scripts directory
+    #   become: true
+    #   ansible.builtin.file:
+    #     path: "{{ omero_server_basedir }}/OMERO.server/lib/\
+    #       scripts/omero/figure_scripts"
+    #     state: directory
+    #     mode: 0755
+    #     recurse: true
+    #     owner: "omero-server"
+    #     group: "omero-server"
 
-    - name: Download the Figure_To_Pdf.py script
-      become: true
-      ansible.builtin.get_url:
-        url: "https://raw.githubusercontent.com/ome/omero-figure/\
-          {{ omero_figure_script_release }}/omero_figure/scripts/omero/\
-          figure_scripts/Figure_To_Pdf.py"
-        dest: "{{ omero_server_basedir }}/OMERO.server/lib/\
-          scripts/omero/figure_scripts/Figure_To_Pdf.py"
-        mode: 0755
-        owner: "omero-server"
-        group: "omero-server"
-        force: true
+    # - name: Download the Figure_To_Pdf.py script
+    #   become: true
+    #   ansible.builtin.get_url:
+    #     url: "https://raw.githubusercontent.com/ome/omero-figure/\
+    #       {{ omero_figure_script_release }}/omero_figure/scripts/omero/\
+    #       figure_scripts/Figure_To_Pdf.py"
+    #     dest: "{{ omero_server_basedir }}/OMERO.server/lib/\
+    #       scripts/omero/figure_scripts/Figure_To_Pdf.py"
+    #     mode: 0755
+    #     owner: "omero-server"
+    #     group: "omero-server"
+    #     force: true
+
+    - name: check if server.key file exists
+      stat: 
+        path: /etc/ssl/omero/server.key
+      register: serverkey_file
+
+    - name: Set omero_certificates_key to server.key
+      set_fact:
+        omero_certificates_key_override: server.key 
+      when: serverkey_file.stat.exists
+    
+  omero_server_selfsigned_certificates: false
 
   vars:
+    icessl_default_dir_self: "{{ omero_server_basedir }}/selfsigned"
+    icessl_default_dir_noself: "/etc/ssl/omero"
+    icessl_default_dir: "{{ icessl_default_dir_self if omero_server_selfsigned_certificate else icessl_default_dir_noself }}"
+    omero_certificates_owner:
+    omero_certificates_key: >-
+      {{ omero_certificates_key_override | default('') }}
     nginx_version: 1.26.2
     omero_figure_release: >-
       {{ omero_figure_release_override | default('7.2.1') }}
@@ -276,12 +294,12 @@
 
     omero_server_config_set:
       omero.client.icetransports: ssl,wss,tcp
-      omero.certificates.key: server.key
+      omero.certificates.key: "{{ omero_certificates_key }}"
       omero.db.poolsize: 60
       omero.glacier2.IceSSL.Ciphers: "HIGH:!DHE"
       omero.glacier2.IceSSL.CAs: server.pem
       omero.glacier2.IceSSL.CertFile: server.p12
-      omero.glacier2.IceSSL.DefaultDir: /etc/ssl/omero
+      omero.glacier2.IceSSL.DefaultDir: "{{ icessl_default_dir }}"
       # This password doesn't need to be secret
       omero.glacier2.IceSSL.Password: secret
       omero.jvmcfg.percent.blitz: 50
@@ -306,8 +324,6 @@
       - "reportlab<3.6"
       - markdown
       - "omero-py>={{ omero_py_release }}"
-
-    omero_server_selfsigned_certificates: false
 
     omero_web_config_set:
       omero.mail.config: true

--- a/playbooks/ome-demoserver.yml
+++ b/playbooks/ome-demoserver.yml
@@ -4,7 +4,7 @@
 # also pass `--extra-vars upgrade_webapps=True`
 
 - name: Demo server playbook
-  hosts: ome-demoservers
+  hosts: ome-demoservers-test
   pre_tasks:
     - name: Install open-vm-tools if system is a VMware vm
       become: true
@@ -31,13 +31,13 @@
       # no_log: true
       postgresql_databases:
       - name: omero
-        owner: demo
+        owner: omero-x
       postgresql_users:
       - user: "{{ omero_server_dbuser | default('omero') }}"
         password: "{{ omero_server_dbpassword | default('omero') }}"
         databases: []
 
-    - role: ome.omero_server
+    - role: omero_server
       # Defaults overridden in private configuration
       # omero_server_dbuser:
       # omero_server_dbpassword:
@@ -61,23 +61,23 @@
         - "omero-signup=={{ omero_signup_release }}"
         - "omero-py>={{ omero_py_release }}"
 
-    - role: ome.omero_user
-      no_log: true
-      omero_user_system: omero-server
-      omero_user_admin_user: root
-      omero_user_admin_pass: "{{ omero_server_rootpassword }}"
-      omero_group_create:
-        - name: public
-          type: read-only
-        - name: "My Data"
-          type: private
-      omero_user_create:
-        - login: "{{ secret_omero_web_public_user | default('public') }}"
-          firstname: Public
-          lastname: User
-          password: >-
-            {{ secret_omero_web_public_password | default('public') }}
-          groups: "--group-name public"
+    # - role: ome.omero_user
+    #   no_log: true
+    #   omero_user_system: omero-server
+    #   omero_user_admin_user: root
+    #   omero_user_admin_pass: "{{ omero_server_rootpassword }}"
+    #   omero_group_create:
+    #     - name: public
+    #       type: read-only
+    #     - name: "My Data"
+    #       type: private
+    #   omero_user_create:
+    #     - login: "{{ secret_omero_web_public_user | default('public') }}"
+    #       firstname: Public
+    #       lastname: User
+    #       password: >-
+    #         {{ secret_omero_web_public_password | default('public') }}
+    #       groups: "--group-name public"
 
     - role: ome.ssl_certificate
       tags: ssl
@@ -220,7 +220,7 @@
         force: true
   
   vars:
-    omero_server_selfsigned_certificates: true
+    omero_server_selfsigned_certificates: false
     icessl_default_dir_self: "{{ omero_server_basedir }}/selfsigned"
     icessl_default_dir_noself: "/etc/ssl/omero"
     icessl_default_dir: "{{ icessl_default_dir_self if omero_server_selfsigned_certificates else icessl_default_dir_noself }}"
@@ -246,7 +246,7 @@
       {{ omero_signup_release_override | default('0.3.3') }}
 
     omero_server_release: >-
-      {{ omero_server_release_override | default('5.6.14') }}
+      {{ omero_server_release_override | default('5.6.16') }}
     omero_web_release: "{{ omero_web_release_override | default('5.29.2') }}"
     omero_py_release: "{{ omero_py_release_override | default('5.21.0') }}"
     # For https://github.com/openmicroscopy/ansible-role-java,

--- a/playbooks/ome-demoserver.yml
+++ b/playbooks/ome-demoserver.yml
@@ -62,7 +62,7 @@
         - "omero-signup=={{ omero_signup_release }}"
         - "omero-py>={{ omero_py_release }}"
 
-    - role: ome.omero_user
+    - role: omero_user
       no_log: true
       omero_user_system: omero-server
       omero_user_admin_user: root

--- a/playbooks/ome-demoserver.yml
+++ b/playbooks/ome-demoserver.yml
@@ -275,13 +275,13 @@
     filesystem: "xfs"
 
     omero_server_config_set:
-      omero.certificates.owner: "/C=UK/ST=Scotland/L=Dundee/O=OME"
       omero.client.icetransports: ssl,wss,tcp
+      omero.certificates.key: server.key
       omero.db.poolsize: 60
-      omero.glacier2.IceSSL.Ciphers: "ADH:HIGH"
-      omero.glacier2.IceSSL.DefaultDir: "{{ omero_server_basedir }}/selfsigned"
+      omero.glacier2.IceSSL.Ciphers: "HIGH:!DHE"
       omero.glacier2.IceSSL.CAs: server.pem
       omero.glacier2.IceSSL.CertFile: server.p12
+      omero.glacier2.IceSSL.DefaultDir: /etc/ssl/omero
       # This password doesn't need to be secret
       omero.glacier2.IceSSL.Password: secret
       omero.jvmcfg.percent.blitz: 50

--- a/playbooks/ome-demoserver.yml
+++ b/playbooks/ome-demoserver.yml
@@ -218,20 +218,20 @@
     omero_fpbioimage_release: >-
       {{ omero_fpbioimage_release_override | default('0.4.1') }}
     omero_iviewer_release: >-
-      {{ omero_iviewer_release_override | default('0.15.0') }}
+      {{ omero_iviewer_release_override | default('0.16.0') }}
     omero_parade_release: >-
       {{ omero_parade_release_override | default('0.2.4') }}
     omero_autotag_release: >-
-      {{ omero_autotag_release_override | default('4.0.1') }}
+      {{ omero_autotag_release_override | default('4.1.0') }}
     omero_tagsearch_release: >-
-      {{ omero_tagsearch_release_override | default('4.2.0') }}
+      {{ omero_tagsearch_release_override | default('4.3.0') }}
     omero_signup_release: >-
       {{ omero_signup_release_override | default('0.3.3') }}
 
     omero_server_release: >-
       {{ omero_server_release_override | default('5.6.14') }}
-    omero_web_release: "{{ omero_web_release_override | default('5.28.0') }}"
-    omero_py_release: "{{ omero_py_release_override | default('5.19.5') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.29.2') }}"
+    omero_py_release: "{{ omero_py_release_override | default('5.21.0') }}"
     # For https://github.com/openmicroscopy/ansible-role-java,
     # which is a dependency.
     java_jdk_install: true

--- a/playbooks/ome-demoserver.yml
+++ b/playbooks/ome-demoserver.yml
@@ -219,7 +219,7 @@
         omero_certificates_key_override: server.key 
       when: serverkey_file.stat.exists
     
-  omero_server_selfsigned_certificates: false
+  omero_server_selfsigned_certificates: true
 
   vars:
     icessl_default_dir_self: "{{ omero_server_basedir }}/selfsigned"

--- a/playbooks/ome-demoserver.yml
+++ b/playbooks/ome-demoserver.yml
@@ -223,7 +223,7 @@
         force: true
   
   vars:
-    omero_server_selfsigned_certificates: false
+    omero_server_selfsigned_certificates: true
     icessl_default_dir_self: "{{ omero_server_basedir }}/selfsigned"
     icessl_default_dir_noself: "/etc/ssl/omero"
     icessl_default_dir: "{{ icessl_default_dir_self if omero_server_selfsigned_certificates else icessl_default_dir_noself }}"

--- a/playbooks/ome-demoserver.yml
+++ b/playbooks/ome-demoserver.yml
@@ -307,7 +307,7 @@
       - markdown
       - "omero-py>={{ omero_py_release }}"
 
-    omero_server_selfsigned_certificates: true
+    omero_server_selfsigned_certificates: false
 
     omero_web_config_set:
       omero.mail.config: true

--- a/playbooks/ome-demoserver.yml
+++ b/playbooks/ome-demoserver.yml
@@ -52,7 +52,7 @@
         - "omero-py>={{ omero_py_release }}"
 
     - role: ome.omero_user
-      no_log: true
+      # no_log: true
       omero_user_system: omero-server
       omero_user_admin_user: root
       omero_user_admin_pass: "{{ omero_server_rootpassword }}"

--- a/playbooks/ome-demoserver.yml
+++ b/playbooks/ome-demoserver.yml
@@ -29,17 +29,15 @@
 
     - role: ome.postgresql
       # no_log: true
-      tags: ssl
       postgresql_databases:
       - name: omero
-        owner: omero-x
+        owner: demo
       postgresql_users:
       - user: "{{ omero_server_dbuser | default('omero') }}"
         password: "{{ omero_server_dbpassword | default('omero') }}"
         databases: []
 
-    - role: omero_server
-      # tags: ssl
+    - role: ome.omero_server
       # Defaults overridden in private configuration
       # omero_server_dbuser:
       # omero_server_dbpassword:

--- a/playbooks/ome-demoserver.yml
+++ b/playbooks/ome-demoserver.yml
@@ -15,6 +15,16 @@
            ((ansible_virtualization_type is defined)
            and (ansible_virtualization_type == "VMware"))
 
+    - name: Check if server.key file exists
+      stat: 
+        path: /etc/ssl/omero/server.key
+      register: serverkey_file
+
+    - name: Set omero_certificates_key to server.key
+      set_fact:
+        omero_certificates_key_override: server.key 
+      when: serverkey_file.stat.exists
+
   roles:
 
     - role: ome.postgresql
@@ -208,20 +218,9 @@
         owner: "omero-server"
         group: "omero-server"
         force: true
-
-    - name: check if server.key file exists
-      stat: 
-        path: /etc/ssl/omero/server.key
-      register: serverkey_file
-
-    - name: Set omero_certificates_key to server.key
-      set_fact:
-        omero_certificates_key_override: server.key 
-      when: serverkey_file.stat.exists
-    
-  omero_server_selfsigned_certificates: true
-
+  
   vars:
+    omero_server_selfsigned_certificates: true
     icessl_default_dir_self: "{{ omero_server_basedir }}/selfsigned"
     icessl_default_dir_noself: "/etc/ssl/omero"
     icessl_default_dir: "{{ icessl_default_dir_self if omero_server_selfsigned_certificate else icessl_default_dir_noself }}"

--- a/playbooks/ome-demoserver.yml
+++ b/playbooks/ome-demoserver.yml
@@ -37,7 +37,7 @@
         password: "{{ omero_server_dbpassword | default('omero') }}"
         databases: []
 
-    - role: ome.omero_server
+    - role: omero_server
       # Defaults overridden in private configuration
       # omero_server_dbuser:
       # omero_server_dbpassword:

--- a/playbooks/ome-demoserver.yml
+++ b/playbooks/ome-demoserver.yml
@@ -62,7 +62,7 @@
         - "omero-py>={{ omero_py_release }}"
 
     - role: ome.omero_user
-      # no_log: true
+      no_log: true
       omero_user_system: omero-server
       omero_user_admin_user: root
       omero_user_admin_pass: "{{ omero_server_rootpassword }}"

--- a/playbooks/ome-demoserver.yml
+++ b/playbooks/ome-demoserver.yml
@@ -322,7 +322,7 @@
       - "omero-metadata=={{ omero_metadata_release }}"
       - "omero-demo-cleanup==0.2.1"
       # For OMERO.figure script
-      - "reportlab<3.6"
+      - "reportlab"
       - markdown
       - "omero-py>={{ omero_py_release }}"
 

--- a/playbooks/ome-demoserver.yml
+++ b/playbooks/ome-demoserver.yml
@@ -301,6 +301,8 @@
       omero.glacier2.IceSSL.DefaultDir: "{{ icessl_default_dir }}"
       # This password doesn't need to be secret
       omero.glacier2.IceSSL.Password: secret
+      omero.glacier2.IceSSL.ProtocolVersionMax: TLS1_3
+      omero.glacier2.IceSSL.Protocols: TLS1_2,TLS1_3
       omero.jvmcfg.percent.blitz: 50
       omero.jvmcfg.percent.indexer: 20
       omero.jvmcfg.percent.pixeldata: 20

--- a/playbooks/roles/.gitignore
+++ b/playbooks/roles/.gitignore
@@ -1,2 +1,0 @@
-roles
-.vagrant

--- a/requirements.yml
+++ b/requirements.yml
@@ -39,8 +39,11 @@
   src: https://github.com/pwalczysko/ansible-role-omero-web
   version: p312
 
-- src: ome.nginx
-  version: 2.2.1
+# - src: ome.nginx
+#   version: 2.2.1
+- name: nginx
+  src: https://github.com/pwalczysko/ansible-role-nginx
+  version: nginx-repo
 
 - src: ome.redis
   version: 1.3.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -75,8 +75,11 @@
 - src: ome.postgresql_backup
   version: 0.3.0
 
-- src: ome.omero_user
-  version: 0.4.0
+# - src: ome.omero_user
+#   version: 0.4.0
+- name: omero_user
+  src: https://github.com/pwalczysko/ansible-role-omero_user
+  version: include
 
 - src: ome.lvm_partition
   version: 1.2.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -78,7 +78,7 @@
 # - src: ome.omero_user
 #   version: 0.4.0
 - name: omero_user
-  src: https://github.com/pwalczysko/ansible-role-omero_user
+  src: https://github.com/pwalczysko/ansible-role-omero-user
   version: include
 
 - src: ome.lvm_partition

--- a/requirements.yml
+++ b/requirements.yml
@@ -24,8 +24,11 @@
 - src: ome.deploy_archive
   version: 0.2.0
 
-- src: ome.omero_server
-  version: 6.1.0
+# - src: ome.omero_server
+#   version: 6.1.0
+- name: omero_server
+  src: https://github.com/sbesson/ansible-role-omero-server
+  version: no_update_cache
 
 - src: ome.omero_web
   version: 5.1.1

--- a/requirements.yml
+++ b/requirements.yml
@@ -9,8 +9,11 @@
 - src: ome.java
   version: 2.2.0
 
-- src: ome.python3_virtualenv
-  version: 0.2.0
+# - src: ome.python3_virtualenv
+#   version: 0.2.0
+- name: python3_virtualenv
+  src: https://github.com/khaledk2/ansible-role-python3-virtualenv
+  version: update_ansible_python
 
 - src: ome.ice
   version: 4.4.4
@@ -24,14 +27,17 @@
 - src: ome.deploy_archive
   version: 0.2.0
 
-# - src: ome.omero_server
-#   version: 6.1.0
+- src: ome.omero_server
+  version: 6.1.0
 - name: omero_server
-  src: https://github.com/sbesson/ansible-role-omero-server
-  version: no_update_cache
+  src: https://github.com/pwalczysko/ansible-role-omero-server
+  version: python-vers
 
-- src: ome.omero_web
-  version: 5.1.1
+# - src: ome.omero_web
+#   version: 5.1.1
+- name: omero_web
+  src: https://github.com/ome/ansible-role-omero-web
+  version: master
 
 - src: ome.nginx
   version: 2.2.1

--- a/requirements.yml
+++ b/requirements.yml
@@ -27,8 +27,8 @@
 - src: ome.deploy_archive
   version: 0.2.0
 
-- src: ome.omero_server
-  version: 6.1.0
+# - src: ome.omero_server
+#   version: 6.1.0
 - name: omero_server
   src: https://github.com/pwalczysko/ansible-role-omero-server
   version: python-vers
@@ -36,8 +36,8 @@
 # - src: ome.omero_web
 #   version: 5.1.1
 - name: omero_web
-  src: https://github.com/ome/ansible-role-omero-web
-  version: master
+  src: https://github.com/pwalczysko/ansible-role-omero-web
+  version: p312
 
 - src: ome.nginx
   version: 2.2.1


### PR DESCRIPTION
This is a follow-up on the align -certs work in https://github.com/ome/prod-playbooks/pull/384. 

The main task is to upgrade the framework for python 3.12 and remove capping for ansible. 

The branches from repos like ``ansible-role-omero-server`` and similar for ``web``, ``nginx``, ``omero-user``, were inserted into ``requirements.yml``.

The tests are passing here.

ToDo: Clear up the suspicion that in real-life run on VM this playbook fails on the postgres role or fix the problem.