### PR TITLE
Molecule specific tasks

### DIFF
--- a/molecule/rockylinux9/molecule.yml
+++ b/molecule/rockylinux9/molecule.yml
@@ -24,6 +24,8 @@ platforms:
       - ome-demoservers
 provisioner:
   name: ansible
+  env:
+    RUNNING_IN_MOLECULE: "true"
   playbooks:
     prepare: prepare.yml
     converge: ../../playbooks/ome-demoserver.yml

--- a/molecule/ubuntu2204/molecule.yml
+++ b/molecule/ubuntu2204/molecule.yml
@@ -24,6 +24,8 @@ platforms:
       - ome-demoservers
 provisioner:
   name: ansible
+  env:
+    RUNNING_IN_MOLECULE: "true"
   playbooks:
     prepare: prepare.yml
     converge: ../../playbooks/ome-demoserver.yml

--- a/molecule/ubuntu2204/molecule.yml
+++ b/molecule/ubuntu2204/molecule.yml
@@ -24,6 +24,8 @@ platforms:
       - ome-demoservers
 provisioner:
   name: ansible
+  # Helper variable to decide between
+  # run in molecule and outside molecule in playbook
   env:
     RUNNING_IN_MOLECULE: "true"
   playbooks:

--- a/molecule/ubuntu2204/prepare.yml
+++ b/molecule/ubuntu2204/prepare.yml
@@ -3,11 +3,21 @@
   hosts: all
 
   # If testing in Docker cron won't be installed
+  # dirmngr is necessary for java install in Ubuntu
   pre_tasks:
     - name: Install cron
       become: true
       ansible.builtin.apt:
         update_cache: true
         cache_valid_time: 86400
-        name: cron
+        name:
+          - cron
+          - dirmngr
         state: present
+
+   # Necessary for java install on ubuntu systemd docker images
+    - name: system packages | Ensure the man directory exists
+      ansible.builtin.file:
+        path: /usr/share/man/man1
+        state: directory
+        mode: '0755'

--- a/playbooks/ome-demoserver.yml
+++ b/playbooks/ome-demoserver.yml
@@ -233,7 +233,8 @@
   
   vars:
     # python_version: "3.12"
-    omero_server_selfsigned_certificates: true
+    omero_server_selfsigned_certificates: >-
+      {{ (lookup('env', 'RUNNING_IN_MOLECULE') == "true") | default(false) }}
     icessl_default_dir_self: "{{ omero_server_basedir }}/selfsigned"
     icessl_default_dir_noself: "/etc/ssl/omero"
     icessl_default_dir: "{{ icessl_default_dir_self if omero_server_selfsigned_certificates else icessl_default_dir_noself }}"

--- a/playbooks/ome-demoserver.yml
+++ b/playbooks/ome-demoserver.yml
@@ -232,11 +232,21 @@
         force: true
   
   vars:
-    # python_version: "3.12"
+    # "3.12" is default python_version
+    # "3.11" is also supported.
+    python_version: "3.12"
+    # Certificates are often not selfsigned when
+    # running in production systems
+    # but must be selfsigned in molecule
+    # RINNING_IN_MOLECULE indicates the running env.
     omero_server_selfsigned_certificates: >-
       {{ (lookup('env', 'RUNNING_IN_MOLECULE') == "true") | default(false) }}
     icessl_default_dir_self: "{{ omero_server_basedir }}/selfsigned"
     icessl_default_dir_noself: "/etc/ssl/omero"
+    # Production system certificates tend to be
+    # in a different dir than selfsigned certs.
+    # "icessl_default_dir_noself" determines the
+    # cert directory in case the certs are not selfsigned.
     icessl_default_dir: "{{ icessl_default_dir_self if omero_server_selfsigned_certificates else icessl_default_dir_noself }}"
     omero_certificates_owner:
     omero_certificates_key: >-

--- a/playbooks/ome-demoserver.yml
+++ b/playbooks/ome-demoserver.yml
@@ -251,16 +251,16 @@
     omero_parade_release: >-
       {{ omero_parade_release_override | default('0.2.4') }}
     omero_autotag_release: >-
-      {{ omero_autotag_release_override | default('4.1.0') }}
+      {{ omero_autotag_release_override | default('4.3.0') }}
     omero_tagsearch_release: >-
       {{ omero_tagsearch_release_override | default('4.3.0') }}
     omero_signup_release: >-
       {{ omero_signup_release_override | default('0.3.3') }}
 
     omero_server_release: >-
-      {{ omero_server_release_override | default('5.6.16') }}
-    omero_web_release: "{{ omero_web_release_override | default('5.30.1') }}"
-    omero_py_release: "{{ omero_py_release_override | default('5.21.3') }}"
+      {{ omero_server_release_override | default('5.6.17') }}
+    omero_web_release: "{{ omero_web_release_override | default('5.31.0') }}"
+    omero_py_release: "{{ omero_py_release_override | default('5.22.0') }}"
     # For https://github.com/openmicroscopy/ansible-role-java,
     # which is a dependency.
     java_jdk_install: true

--- a/requirements.yml
+++ b/requirements.yml
@@ -25,7 +25,7 @@
   version: 0.3.0
 
 - src: ome.omero_server
-  version: 7.0.0
+  version: 7.0.1
 
 - src: ome.omero_web
   version: 6.0.0


### PR DESCRIPTION
This PR:

- bumps the ome.omero_server version to 7.0.1 as it is crucial for functioning to have ``omego==0.8.0``
- introduces the variable ``RUNNING_IN_MOLECULE`` to discern the molecule-specific tasks and uses it for the ``omero_server_selfsigned_certificates`` values (this helps with the usage of the playbook for our prod server, where the selfsigned is always ``false``, whereas in molecule it must be true).
- adds installation of ``dirmngr`` for ubuntu, as this is necessary to run the java installation without the previous ome.postgresql role usage in the playbook
- bumps the versions of server, web, omero-py and webapps


cc @khaledk2 