### PR TITLE
Adjust django-redis version

### DIFF
--- a/playbooks/ome-demoserver.yml
+++ b/playbooks/ome-demoserver.yml
@@ -67,7 +67,7 @@
         # This is to force minimal Django version - optional
         - "Django>=5.2.10"
         # necessary as omero.web.caches configured with redis
-        - "django-redis==5.3.0"
+        - "django-redis>=6"
 
     - role: ome.omero_user
       no_log: true


### PR DESCRIPTION
Noticed when deploying https://github.com/ome/prod-playbooks/pull/390:
The omero-web 5.31.0 asks for ``django-redis>=6``, see https://github.com/ome/omero-web/blob/4b7b4caff89adad43f4c7a0758f5ad5d5f4dd674/setup.py#L72

This PR:
 - Adjusts django-redis version according to omero-web repo in https://github.com/ome/omero-web/blob/4b7b4caff89adad43f4c7a0758f5ad5d5f4dd674/setup.py#L72
 - This is already deployed on ome-demoserver now successfully

```
((venv-3.12) ) [root@ome-demo-ap1 venv3]# pip freeze | grep dja
django-cors-headers==3.7.0
django-pipeline==4.1.0
django-redis==6.0.0
```